### PR TITLE
feat(adapter): add QueryBuilderAdapter for one-shot hydration and two-way binding

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist/
+docs/

--- a/README.md
+++ b/README.md
@@ -418,6 +418,30 @@ adapter: createSearchParamsAdapter({
 }),
 ```
 
+### Hide noisy state from the URL: `urlOmit`
+
+Sometimes the builder carries entries your **backend needs but your user shouldn't see in the URL bar**. Typical case: default includes/fields the API always requires (`include=organization,permissions`) that just clutter shareable links.
+
+`urlOmit` is a writer-only denylist per bucket. The listed names stay in state (so `.build()` still emits them to the API), they just don't reach the URL:
+
+```ts
+useQueryBuilder({
+  includes: ["organization", "permissions"],     // always sent to API
+  adapter: createSearchParamsAdapter({
+    sync: true,
+    urlOmit: { includes: ["organization", "permissions"] },
+  }),
+});
+
+builder.filter("status", "active");
+// .build() → ?filter[status]=active&include=organization,permissions   ← backend
+// URL bar  → ?filter[status]=active                                    ← user
+```
+
+Alias-aware on `filters` and `sorts` — list a name in either vocabulary (state or URL) and both forms are skipped.
+
+**Note**: `urlOmit` only affects the writer. If a crafted URL contains one of these names, the reader still processes it. Add the same names to `excludeKeys` if you also want to refuse them on hydration.
+
 ### Renaming the URL keys
 
 Sometimes the default URL is verbose:

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ If you set `allowed.filters: ["status", "role"]`, listing `is_admin` in `exclude
 
   Same on the deny side: `excludeKeys: { filters: ["is_admin"] }` blocks both `?filter[is_admin]=...` AND `?filter[adminFlag]=...` (the alias key), so an attacker can't bypass the denylist by switching vocabularies.
 - For `fields`, you can match by short prop (`password`) or by `entity.prop` (`user.password`). Pick the precision you need.
-- `page` and `limit` are **not** auto-hydrated. If you want them on the URL, add them to `allowed.params` and treat them as raw params.
+- `page` and `limit` are **auto-hydrated** when present in the URL and emitted by the writer when set in `state.pagination`. Round-trips out of the box — no extra config.
 - **Why per bucket?** `password` is dangerous as a filter but fine as a `fields` selection (it's just picking which column the API returns). One flat list would force you into all-or-nothing.
 
 ### Want a different source? Write your own adapter

--- a/README.md
+++ b/README.md
@@ -506,6 +506,19 @@ serializeSearchParams({
 
 Both accept the same `keys` / `aliases` / `allowed` / `excludeKeys` options as the adapter.
 
+### Known limitations
+
+The URL protocol uses a few characters as control symbols. Filter values containing them **silently corrupt** on round-trip — the writer emits the value, but the reader splits it differently. Until we lift this limitation, treat these as off-limits inside filter values:
+
+| Character | Why it breaks |
+|---|---|
+| `,` | Multi-value separator — `filter[tag]=a,b` becomes `["a", "b"]` on parse |
+| `<`, `>`, `<=`, `>=`, `<>` (as a **leading** prefix) | Operator syntax — `filter[age]=>=18` becomes operator `>=` + value `["18"]` |
+
+Other "special-looking" characters like `%`, `&`, `+` and spaces are fine — they travel URL-escaped and survive the round-trip intact.
+
+If you need any of these characters inside a value (e.g. tags with commas), keep that piece of state outside the URL adapter, or escape it on your side before passing it to `.filter()`.
+
 ---
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -299,21 +299,11 @@ The conflict is **bidirectional by default** — you only need to declare it onc
 
 ## Hydrating from URL
 
-The builder bridges to external state sources through an `adapter`. An adapter is any object that implements `QueryBuilderAdapter`:
+Say you have a list view with filters, sorts and pagination. A user picks "status = active", sorts by date, opens page 3 — and shares the link with a teammate. You want that link to open with the exact same filters already applied.
 
-```ts
-interface QueryBuilderAdapter<Aliases> {
-  read: () => Partial<GlobalState<Aliases>>;
-  write?: (state: GlobalState<Aliases>) => void;
-}
-```
+That's what an **adapter** does: it bridges the builder to an external source (URL, `localStorage`, anything you want). The built-in `createSearchParamsAdapter` handles the URL case.
 
-- `read()` is called **exactly once** when the builder is created — like the lazy form of `useState(() => ...)`. Its return value seeds the initial state.
-- `write(state)` is optional. When defined, it runs on every state change so the external source can stay in sync (two-way binding).
-
-### Reading the current URL
-
-For the most common case — reading the page's query string — use the built-in `createSearchParamsAdapter`:
+### The 30-second example
 
 ```ts
 import {
@@ -321,114 +311,200 @@ import {
   createSearchParamsAdapter,
 } from "@cgarciagarcia/react-query-builder";
 
-const urlAdapter = createSearchParamsAdapter({
-  // Optionally remap the keys the parser looks for in the URL.
-  // Anything you omit keeps its default ("filter", "sort", "include", "fields").
-  keys: {
-    filter: "filt",
-    sort:   "srt",
-    include:"inc",
-    fields: "fld",
-  },
-  // Query params that are not filter/sort/include/fields are ignored unless
-  // you list them here. They land in `state.params`.
-  allowedParams: ["locale", "tenant"],
-});
-
-const builder = useQueryBuilder({ adapter: urlAdapter });
-```
-
-Visiting `?filt[status]=active&srt=-name&inc=user&fld[user]=id,email&locale=es` produces a builder whose `build()` returns
-
-```
-?filter[status]=active&fields[user]=id,email&sort=-name&include=user&locale=es
-```
-
-(The output always uses the library's default keys — the renamed keys are only for **reading** from the URL.)
-
-### Notes
-
-- **One-shot read.** `read()` runs only at builder creation; later URL changes do **not** re-hydrate. Use `sync` (see below) if you want the URL to follow builder mutations.
-- **Precedence.** Explicit config wins over `adapter.read()`. Passing `filters: [...]` alongside an adapter overrides the seeded filters entirely.
-- **SSR friendly.** The default `source` of `createSearchParamsAdapter` is `() => window.location.search`, evaluated inside `read()`. The default returns `""` when `window` is not available, so it never throws in Node.
-- **`page` / `limit` are not auto-hydrated** out of the box — add them to `allowedParams` if you need them preserved as raw params.
-
-### Aliases (round-trip with `.build()`)
-
-When you pass `aliases` to the builder, the adapter automatically picks them up (via the `read({ aliases })` context) so the URL ends up in **wire / backend space** — exactly what `.build()` produces — while your state stays in **frontend space**. The reader applies the reverse map (URL `name` → state `userName`), the writer applies the forward map (state `userName` → URL `name`).
-
-```ts
-const aliases = { userName: "name" } as const;
-
-useQueryBuilder({
-  aliases,
+const builder = useQueryBuilder({
   adapter: createSearchParamsAdapter({ sync: true }),
 });
 
-// Navigating to ?filter[name]=John hydrates filters: [{ attribute: "userName", … }].
-// builder.filter("userName", "Jane") writes ?filter[name]=Jane to the URL.
+builder.filter("status", "active").sort("created_at", "desc");
+// URL bar is now: /?filter[status]=active&sort=-created_at
 ```
 
-You can also pass `aliases` directly to `createSearchParamsAdapter` if you don't want the adapter to depend on builder config.
+Refresh the page, share the link — the filters come back. That's it.
 
-### Defense-in-depth: `excludeKeys`
+What just happened:
+- On mount, the adapter **reads** the current URL and seeds the builder.
+- `sync: true` makes the adapter **write** back on every change (`history.replaceState`).
+- The URL output mirrors what `.build()` produces, so your backend and your URL bar agree.
 
-URL params are user-controlled. A crafted link like `?filter[is_admin]=true` would otherwise flow straight into your state and out to the backend. `excludeKeys` is an explicit denylist of attribute names that get silently dropped on read (and overrides `allowedParams`):
+### Read-only hydration (no URL writes)
+
+If you only want to hydrate at mount and never touch the URL after, just leave `sync` out:
 
 ```ts
-createSearchParamsAdapter({
-  allowedParams: ["locale"],
-  excludeKeys: ["is_admin", "password", "tenant_id", "secret_relation"],
+useQueryBuilder({
+  adapter: createSearchParamsAdapter(),
 });
 ```
 
-Applies to filter / sort / include / fields / params. Matched on the raw URL name (backend) before any reverse alias.
+Now `read()` runs once when the hook mounts — same semantics as `useState(() => …)` — and that's the end of it. URL changes after mount don't re-hydrate.
 
-### Two-way binding with `sync`
+### Customising the writer
 
-The built-in writer is opt-in via `sync`:
+`sync` accepts three forms depending on how aggressive you want the URL updates to be:
 
 ```ts
-// Replace the URL on every mutation (no extra history entries)
-createSearchParamsAdapter({ sync: true });          // or: sync: "replace"
+// 1) Default behavior: replaceState (no extra browser history entries)
+createSearchParamsAdapter({ sync: true });           // alias for "replace"
 
-// Add a history entry per mutation
+// 2) pushState (every change is a back-button step)
 createSearchParamsAdapter({ sync: "push" });
 
-// Full custom: hand the serialised search string to a router or debouncer
+// 3) Bring your own — useful for Next.js / React Router / debouncing
 createSearchParamsAdapter({
   sync: (search) => router.replace({ search }),
 });
 ```
 
-The default writer **preserves any query params not managed by this adapter** (anything that does not match the configured `keys` or `allowedParams`). Third-party params like `utm_source`, `gclid`, `theme`, etc. stay intact — only your managed keys are added, updated, or cleared.
+Don't worry about other apps' query params — the writer **preserves anything it doesn't recognise**. So `?utm_source=newsletter` or `?theme=dark` stays untouched while your filters get added, updated, or cleared.
 
-### Custom adapters
+### Aliases: keep your frontend names, ship backend names
 
-`QueryBuilderAdapter` is just `{ read, write? }`. Any source — `react-router`'s search params, a hash fragment, an in-memory store, `localStorage` — can be wrapped as an adapter:
+You probably name things one way in the UI (`userName`, `createdAt`) and another in the API (`name`, `created_at`). Pass `aliases` to the builder and the adapter handles the translation in **both directions** automatically:
 
 ```ts
-const memoryAdapter: QueryBuilderAdapter = {
-  read:  () => store.get(),
-  write: (state) => store.set(state),
+useQueryBuilder({
+  aliases: { userName: "name", createdAt: "created_at" },
+  adapter: createSearchParamsAdapter({ sync: true }),
+});
+
+// Your code keeps using frontend names:
+builder.filter("userName", "Jane").sort("createdAt", "desc");
+
+// The URL bar shows backend names (same as .build() would emit):
+// /?filter[name]=Jane&sort=-created_at
+
+// On refresh, ?filter[name]=Jane hydrates back as { userName: "Jane" }.
+```
+
+The adapter automatically reads aliases from the builder config, so you only declare them once.
+
+### Renaming the URL keys
+
+Sometimes the default URL is verbose:
+
+```
+?filter[status]=active&filter[role]=admin&sort=-created_at&include=author,tags&fields[user]=id,name
+```
+
+That's a mouthful — long enough to overflow in chat previews, ugly to share, and harder to scan. Remap the keys to shorten it:
+
+```ts
+createSearchParamsAdapter({
+  keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
+  sync: true,
+});
+```
+
+Now the same state produces:
+
+```
+?filt[status]=active&filt[role]=admin&srt=-created_at&inc=author,tags&fld[user]=id,name
+```
+
+Why you might want this:
+
+- **Shorter, more shareable links** — saves bytes per param, big difference when you have many filters.
+- **Cleaner URL bar** — easier on the eye for users and for screenshots in support tickets.
+- **Brand or domain language** — your app says "query", not "filter"? Match the vocabulary your users already know.
+- **Avoiding collisions** — if the surrounding app already uses `?filter=...` or `?sort=...` for something else, rename to coexist.
+
+Both reader and writer use the new keys, so round-trips still work. This **only** affects the URL bar — `.build()` (what you pass to `fetch`) keeps using the canonical `filter`/`sort`/… names your backend expects.
+
+### Locking down which keys can come from the URL
+
+The URL is user input. Without limits, a crafted link like `?filter[is_admin]=true` would flow straight into your `.build()` call and out to your backend. You have two primitives, **per bucket**, and you pick the one that matches your situation:
+
+#### `allowed` — strict allowlist ("only these")
+
+Use it when you have a short, explicit list of what's legitimate:
+
+```ts
+createSearchParamsAdapter({
+  allowed: {
+    filters: ["status", "role", "created_at"],
+    sorts:   ["created_at", "name"],
+    params:  ["locale", "tenant"],   // anything not here is dropped
+  },
+});
+```
+
+Defaults when you omit a bucket:
+- `filters` / `sorts` / `includes` / `fields` → allow everything (so the URL can drive filtering freely)
+- `params` → allow nothing (the catch-all is deny-by-default — params are arbitrary, so you must opt-in by listing them)
+
+#### `excludeKeys` — targeted denylist ("everything except these")
+
+Use it when you trust the bucket in general but want to block a handful of dangerous names — without enumerating everything legitimate:
+
+```ts
+createSearchParamsAdapter({
+  // No allowed.filters → I accept any filter from the URL.
+  // I have 47 legitimate filter attributes and I add more every month;
+  // maintaining a full whitelist is brittle. But is_admin and password
+  // must NEVER come through the URL.
+  excludeKeys: {
+    filters: ["is_admin", "password"],
+  },
+});
+```
+
+#### Which one should I use?
+
+| Situation | Use |
+|---|---|
+| "Short, explicit list of what's allowed" | `allowed` |
+| "Accept everything, except these few" | `excludeKeys` |
+| "Whitelist plus a moving denylist on top" | both (defense in depth) |
+
+If you set `allowed.filters: ["status", "role"]`, listing `is_admin` in `excludeKeys.filters` is **redundant** — it's already dropped because it's not allowed. It doesn't break anything (and reads as documentation of intent), but it's not pulling weight in runtime. The combination is useful when you keep a stable allowlist and want a separate, fast-changing denylist on top.
+
+#### Details that apply to both
+
+- Both apply to the **reader and the writer** symmetrically — the URL bar is always inside your policy.
+- `excludeKeys` always wins over `allowed` (deny beats allow).
+- Matching happens on the **raw URL name (backend)** before reverse-aliasing — that's the threat surface.
+- For `fields`, you can match by short prop (`password`) or by `entity.prop` (`user.password`). Pick the precision you need.
+- `page` and `limit` are **not** auto-hydrated. If you want them on the URL, add them to `allowed.params` and treat them as raw params.
+- **Why per bucket?** `password` is dangerous as a filter but fine as a `fields` selection (it's just picking which column the API returns). One flat list would force you into all-or-nothing.
+
+### Want a different source? Write your own adapter
+
+`QueryBuilderAdapter` is just `{ read, write? }`. Wrap anything:
+
+```ts
+// Persist to localStorage instead of the URL
+const localStorageAdapter: QueryBuilderAdapter = {
+  read:  () => JSON.parse(localStorage.getItem("filters") ?? "{}"),
+  write: (state) => localStorage.setItem("filters", JSON.stringify(state)),
 };
 
-useQueryBuilder({ adapter: memoryAdapter });
+useQueryBuilder({ adapter: localStorageAdapter });
 ```
 
-### Lower level: `parseSearchParams`
+Same pattern works for `react-router` search params, hash routers, in-memory stores, IndexedDB — anything you can read from and write to.
 
-If you only need the parser without the adapter wrapper, it is exported as a pure function:
+### Going lower-level
+
+If you only want the URL parser without the hook integration, both pieces are exported as pure functions:
 
 ```ts
-import { parseSearchParams } from "@cgarciagarcia/react-query-builder";
+import {
+  parseSearchParams,
+  serializeSearchParams,
+} from "@cgarciagarcia/react-query-builder";
 
-parseSearchParams("?filt[status]=active", {
-  keys: { filter: "filt" },
-  allowedParams: ["locale"],
+// URL → state
+parseSearchParams("?filter[status]=active&sort=-name");
+// → { filters: [...], sorts: [{ attribute: "name", direction: "desc" }] }
+
+// state → URL
+serializeSearchParams({
+  filters: [{ attribute: "status", value: ["active"] }],
 });
-// → { filters: [{ attribute: "status", value: ["active"] }] }
+// → "filter[status]=active"
 ```
+
+Both accept the same `keys` / `aliases` / `allowed` / `excludeKeys` options as the adapter.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -348,27 +348,60 @@ Visiting `?filt[status]=active&srt=-name&inc=user&fld[user]=id,email&locale=es` 
 
 ### Notes
 
-- **One-shot read.** `read()` runs only at builder creation; later URL changes do **not** re-hydrate. Define `write` (or add a router listener) if you need to keep the URL in sync with the builder.
+- **One-shot read.** `read()` runs only at builder creation; later URL changes do **not** re-hydrate. Use `sync` (see below) if you want the URL to follow builder mutations.
 - **Precedence.** Explicit config wins over `adapter.read()`. Passing `filters: [...]` alongside an adapter overrides the seeded filters entirely.
 - **SSR friendly.** The default `source` of `createSearchParamsAdapter` is `() => window.location.search`, evaluated inside `read()`. The default returns `""` when `window` is not available, so it never throws in Node.
 - **`page` / `limit` are not auto-hydrated** out of the box — add them to `allowedParams` if you need them preserved as raw params.
 
-### Two-way binding with `write`
+### Aliases (round-trip with `.build()`)
 
-Add a `write` function to push every state change back to the URL (or anywhere else):
+When you pass `aliases` to the builder, the adapter automatically picks them up (via the `read({ aliases })` context) so the URL ends up in **wire / backend space** — exactly what `.build()` produces — while your state stays in **frontend space**. The reader applies the reverse map (URL `name` → state `userName`), the writer applies the forward map (state `userName` → URL `name`).
 
 ```ts
-const adapter: QueryBuilderAdapter = {
-  read:  () => parseSearchParams(window.location.search),
-  write: (state) => {
-    const url = new URL(window.location.href);
-    url.search = buildAction(state); // or any custom serializer
-    window.history.replaceState(null, "", url);
-  },
-};
+const aliases = { userName: "name" } as const;
 
-useQueryBuilder({ adapter });
+useQueryBuilder({
+  aliases,
+  adapter: createSearchParamsAdapter({ sync: true }),
+});
+
+// Navigating to ?filter[name]=John hydrates filters: [{ attribute: "userName", … }].
+// builder.filter("userName", "Jane") writes ?filter[name]=Jane to the URL.
 ```
+
+You can also pass `aliases` directly to `createSearchParamsAdapter` if you don't want the adapter to depend on builder config.
+
+### Defense-in-depth: `excludeKeys`
+
+URL params are user-controlled. A crafted link like `?filter[is_admin]=true` would otherwise flow straight into your state and out to the backend. `excludeKeys` is an explicit denylist of attribute names that get silently dropped on read (and overrides `allowedParams`):
+
+```ts
+createSearchParamsAdapter({
+  allowedParams: ["locale"],
+  excludeKeys: ["is_admin", "password", "tenant_id", "secret_relation"],
+});
+```
+
+Applies to filter / sort / include / fields / params. Matched on the raw URL name (backend) before any reverse alias.
+
+### Two-way binding with `sync`
+
+The built-in writer is opt-in via `sync`:
+
+```ts
+// Replace the URL on every mutation (no extra history entries)
+createSearchParamsAdapter({ sync: true });          // or: sync: "replace"
+
+// Add a history entry per mutation
+createSearchParamsAdapter({ sync: "push" });
+
+// Full custom: hand the serialised search string to a router or debouncer
+createSearchParamsAdapter({
+  sync: (search) => router.replace({ search }),
+});
+```
+
+The default writer **preserves any query params not managed by this adapter** (anything that does not match the configured `keys` or `allowedParams`). Third-party params like `utm_source`, `gclid`, `theme`, etc. stay intact — only your managed keys are added, updated, or cleared.
 
 ### Custom adapters
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Refresh the page, share the link — the filters come back. That's it.
 
 What just happened:
 - On mount, the adapter **reads** the current URL and seeds the builder.
-- `sync: true` makes the adapter **write** back on every change (`history.replaceState`).
+- `sync: true` then **writes once right after mount** to normalise the URL against the final state (so `BaseConfig` defaults, `urlOmit`, or a stale link the user landed on get reconciled immediately — no mutation required), and on every subsequent change.
 - The URL output mirrors what `.build()` produces, so your backend and your URL bar agree.
 
 ### Read-only hydration (no URL writes)
@@ -346,7 +346,7 @@ Now `read()` runs once when the hook mounts — same semantics as `useState(() =
 // 1) Default behavior: replaceState (no extra browser history entries)
 createSearchParamsAdapter({ sync: true });           // alias for "replace"
 
-// 2) pushState (every change is a back-button step)
+// 2) pushState (every mutation is a back-button step)
 createSearchParamsAdapter({ sync: "push" });
 
 // 3) Bring your own — useful for Next.js / React Router / debouncing
@@ -354,6 +354,8 @@ createSearchParamsAdapter({
   sync: (search) => router.replace({ search }),
 });
 ```
+
+**Mount-time normalisation** runs in all three modes — the writer fires once right after the builder is constructed so the URL bar reflects the final state immediately. For `sync: "push"` the very first call still uses `replaceState` (so the mount fire doesn't add a phantom back-button entry); your custom callback also fires once on mount, guard it with a closure flag if that surprises your router.
 
 Don't worry about other apps' query params — the writer **preserves anything it doesn't recognise**. So `?utm_source=newsletter` or `?theme=dark` stays untouched while your filters get added, updated, or cleared.
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,20 @@ builder.filter("status", "active");
 // URL bar  → ?filter[status]=active                                    ← user
 ```
 
+**Wildcard `"*"`** drops every entry in that bucket — useful for `fields`, which are an internal API optimisation the user rarely needs to see in the URL:
+
+```ts
+adapter: createSearchParamsAdapter({
+  sync: true,
+  urlOmit: {
+    fields: ["*"],                                // hide ALL fields from URL
+    includes: ["organization", "permissions"],    // hide only these
+  },
+}),
+```
+
+IDE autocomplete suggests `"*"` thanks to a literal-union typing trick, so it's discoverable while still accepting any plain attribute name.
+
 Alias-aware on `filters` and `sorts` — list a name in either vocabulary (state or URL) and both forms are skipped.
 
 **Note**: `urlOmit` only affects the writer. If a crafted URL contains one of these names, the reader still processes it. Add the same names to `excludeKeys` if you also want to refuse them on hydration.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,46 @@ builder.filter("userName", "Jane").sort("createdAt", "desc");
 
 The adapter automatically reads aliases from the builder config, so you only declare them once.
 
+### Different names for URL and backend
+
+The URL and the backend don't have to share the same naming. Maybe you want the URL to speak the user's language (`?filter[documento]=…`) while your API keeps technical names (`?filter[code]=…`). Or your code uses `rol` in Spanish but the URL should read `type` for shareable links.
+
+Pass `urlAliases` to the adapter independently of the builder's `aliases`:
+
+```ts
+useQueryBuilder({
+  aliases:    { dni: "code", rol: "type" },        // state → backend (drives .build())
+  adapter: createSearchParamsAdapter({
+    sync: true,
+    urlAliases: { dni: "documento", rol: "type" }, // state → URL bar
+  }),
+});
+
+builder.filter("dni", "12345").filter("rol", "admin");
+// URL bar:  ?filter[documento]=12345&filter[type]=admin   ← user sees this
+// .build(): ?filter[code]=12345&filter[type]=admin        ← API receives this
+```
+
+Three independent namespaces for the same logical attribute:
+
+| Layer | Name | Controlled by |
+|---|---|---|
+| State (your code) | `dni`, `rol` | how you call `.filter()` |
+| URL bar | `documento`, `type` | `adapter.urlAliases` |
+| Backend | `code`, `type` | `builder.aliases` |
+
+Omit `urlAliases` to make the URL share the builder's names (the common case). Pass `urlAliases: {}` to explicitly opt out of any URL translation — the URL then mirrors your state-space names verbatim, even when `builder.aliases` is set.
+
+**Security note**: with URL ≠ backend, an attacker who knows the backend name could craft `?filter[code]=…` directly. Lock it down with an allowlist on the adapter:
+
+```ts
+adapter: createSearchParamsAdapter({
+  sync: true,
+  urlAliases: { dni: "documento", rol: "type" },
+  allowed: { filters: ["documento", "type"] },   // backend-name attempts → dropped
+}),
+```
+
 ### Renaming the URL keys
 
 Sometimes the default URL is verbose:
@@ -513,7 +553,7 @@ serializeSearchParams({
 // → "filter[status]=active"
 ```
 
-Both accept the same `keys` / `aliases` / `allowed` / `excludeKeys` options as the adapter.
+Both accept the same `keys` / `urlAliases` / `allowed` / `excludeKeys` options as the adapter.
 
 ### Known limitations
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A TypeScript React hook that builds query strings compatible with [spatie/larave
   - [Pagination](#pagination)
   - [Utilities](#utilities)
 - [Advanced: Conflicting Filters](#advanced-conflicting-filters)
+- [Hydrating from URL](#hydrating-from-url)
 - [Support](#support)
 - [License](#license)
 
@@ -293,6 +294,108 @@ builder.filter('between_dates', ['2024-08-06', '2024-08-13'])
 ```
 
 The conflict is **bidirectional by default** — you only need to declare it once. You can also declare both directions explicitly if you prefer.
+
+---
+
+## Hydrating from URL
+
+The builder bridges to external state sources through an `adapter`. An adapter is any object that implements `QueryBuilderAdapter`:
+
+```ts
+interface QueryBuilderAdapter<Aliases> {
+  read: () => Partial<GlobalState<Aliases>>;
+  write?: (state: GlobalState<Aliases>) => void;
+}
+```
+
+- `read()` is called **exactly once** when the builder is created — like the lazy form of `useState(() => ...)`. Its return value seeds the initial state.
+- `write(state)` is optional. When defined, it runs on every state change so the external source can stay in sync (two-way binding).
+
+### Reading the current URL
+
+For the most common case — reading the page's query string — use the built-in `createSearchParamsAdapter`:
+
+```ts
+import {
+  useQueryBuilder,
+  createSearchParamsAdapter,
+} from "@cgarciagarcia/react-query-builder";
+
+const urlAdapter = createSearchParamsAdapter({
+  // Optionally remap the keys the parser looks for in the URL.
+  // Anything you omit keeps its default ("filter", "sort", "include", "fields").
+  keys: {
+    filter: "filt",
+    sort:   "srt",
+    include:"inc",
+    fields: "fld",
+  },
+  // Query params that are not filter/sort/include/fields are ignored unless
+  // you list them here. They land in `state.params`.
+  allowedParams: ["locale", "tenant"],
+});
+
+const builder = useQueryBuilder({ adapter: urlAdapter });
+```
+
+Visiting `?filt[status]=active&srt=-name&inc=user&fld[user]=id,email&locale=es` produces a builder whose `build()` returns
+
+```
+?filter[status]=active&fields[user]=id,email&sort=-name&include=user&locale=es
+```
+
+(The output always uses the library's default keys — the renamed keys are only for **reading** from the URL.)
+
+### Notes
+
+- **One-shot read.** `read()` runs only at builder creation; later URL changes do **not** re-hydrate. Define `write` (or add a router listener) if you need to keep the URL in sync with the builder.
+- **Precedence.** Explicit config wins over `adapter.read()`. Passing `filters: [...]` alongside an adapter overrides the seeded filters entirely.
+- **SSR friendly.** The default `source` of `createSearchParamsAdapter` is `() => window.location.search`, evaluated inside `read()`. The default returns `""` when `window` is not available, so it never throws in Node.
+- **`page` / `limit` are not auto-hydrated** out of the box — add them to `allowedParams` if you need them preserved as raw params.
+
+### Two-way binding with `write`
+
+Add a `write` function to push every state change back to the URL (or anywhere else):
+
+```ts
+const adapter: QueryBuilderAdapter = {
+  read:  () => parseSearchParams(window.location.search),
+  write: (state) => {
+    const url = new URL(window.location.href);
+    url.search = buildAction(state); // or any custom serializer
+    window.history.replaceState(null, "", url);
+  },
+};
+
+useQueryBuilder({ adapter });
+```
+
+### Custom adapters
+
+`QueryBuilderAdapter` is just `{ read, write? }`. Any source — `react-router`'s search params, a hash fragment, an in-memory store, `localStorage` — can be wrapped as an adapter:
+
+```ts
+const memoryAdapter: QueryBuilderAdapter = {
+  read:  () => store.get(),
+  write: (state) => store.set(state),
+};
+
+useQueryBuilder({ adapter: memoryAdapter });
+```
+
+### Lower level: `parseSearchParams`
+
+If you only need the parser without the adapter wrapper, it is exported as a pure function:
+
+```ts
+import { parseSearchParams } from "@cgarciagarcia/react-query-builder";
+
+parseSearchParams("?filt[status]=active", {
+  keys: { filter: "filt" },
+  allowedParams: ["locale"],
+});
+// → { filters: [{ attribute: "status", value: ["active"] }] }
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,16 @@ If you set `allowed.filters: ["status", "role"]`, listing `is_admin` in `exclude
 
 - Both apply to the **reader and the writer** symmetrically — the URL bar is always inside your policy.
 - `excludeKeys` always wins over `allowed` (deny beats allow).
-- Matching happens on the **raw URL name (backend)** before reverse-aliasing — that's the threat surface.
+- **Alias-aware on `filters` and `sorts`.** When you set `aliases`, the policy matches if **either** the URL-side name (backend) OR the state-side name (frontend) is in the list. Write your rules in whichever vocabulary you think in:
+
+  ```ts
+  aliases: { userName: "name" },
+  allowed: { filters: ["userName"] }   // ✓ allows ?filter[name]=...
+  // — or —
+  allowed: { filters: ["name"] }       // ✓ also allows it
+  ```
+
+  Same on the deny side: `excludeKeys: { filters: ["is_admin"] }` blocks both `?filter[is_admin]=...` AND `?filter[adminFlag]=...` (the alias key), so an attacker can't bypass the denylist by switching vocabularies.
 - For `fields`, you can match by short prop (`password`) or by `entity.prop` (`user.password`). Pick the precision you need.
 - `page` and `limit` are **not** auto-hydrated. If you want them on the URL, add them to `allowed.params` and treat them as raw params.
 - **Why per bucket?** `password` is dangerous as a filter but fine as a `fields` selection (it's just picking which column the API returns). One flat list would force you into all-or-nothing.

--- a/docs/assets/navbar.js
+++ b/docs/assets/navbar.js
@@ -1,0 +1,124 @@
+/**
+ * Shared docs navbar.
+ *
+ * Each page declares its identity via `<html data-page="...">`
+ * (current values: "home", "url-adapter"). The script reads it to mark
+ * the active link and to decide whether anchor links (#install,
+ * #quickstart, …) stay on the current page or jump to index.html.
+ *
+ * The page must include an empty `<div id="navbar"></div>` mount point
+ * where the nav should appear, AND a `<link id="hljs-theme">` element so
+ * the theme toggle can swap the highlight.js stylesheet.
+ */
+(function () {
+  const CURRENT = document.documentElement.dataset.page || "";
+
+  const HLJS_DARK = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css";
+  const HLJS_LIGHT = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css";
+
+  const LOGO_LARAVEL = `<svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Laravel" fill="#FF2D20"><path d="M23.642 5.43a.364.364 0 01.014.1v5.149c0 .135-.073.26-.189.326l-4.323 2.49v4.934a.378.378 0 01-.188.326L9.93 23.949a.316.316 0 01-.066.027c-.008.002-.016.008-.024.01a.348.348 0 01-.192 0c-.011-.002-.02-.008-.03-.012-.02-.008-.042-.014-.062-.025L.533 18.755a.376.376 0 01-.189-.326V2.974c0-.033.005-.066.014-.098.003-.012.01-.02.014-.032a.369.369 0 01.023-.058c.004-.013.015-.022.023-.033l.033-.045c.012-.01.025-.018.037-.027.014-.012.027-.024.041-.034H.53L5.043.05a.375.375 0 01.375 0L9.93 2.647h.002c.015.01.027.021.04.033l.038.027c.013.014.02.03.033.045.008.011.02.021.025.033.01.02.017.038.024.058.003.011.01.021.013.032.01.031.014.064.014.098v9.652l3.76-2.164V5.527c0-.033.004-.066.013-.098.003-.01.01-.02.013-.032a.487.487 0 01.024-.059c.007-.012.018-.02.025-.033.012-.015.021-.03.033-.043.012-.012.025-.02.037-.028.014-.01.026-.023.041-.032h.001l4.513-2.598a.375.375 0 01.375 0l4.513 2.598c.016.01.027.021.042.031.012.01.025.018.036.028.013.014.022.03.034.044.008.012.019.021.024.033.011.02.018.04.024.06.006.01.012.021.015.032zm-.74 5.032V6.179l-1.578.908-2.182 1.256v4.283zm-4.51 7.75v-4.287l-2.147 1.225-6.126 3.498v4.325zM1.093 3.624v14.588l8.273 4.761v-4.325l-4.322-2.445-.002-.003H5.04c-.014-.01-.025-.021-.04-.031-.011-.01-.024-.018-.035-.027l-.001-.002c-.013-.012-.021-.025-.031-.04-.01-.011-.021-.022-.028-.036h-.002c-.008-.014-.013-.031-.02-.047-.006-.016-.014-.027-.018-.043a.49.49 0 01-.008-.057c-.002-.014-.006-.027-.006-.041V5.789l-2.18-1.257zM5.23.81L1.47 2.974l3.76 2.164 3.758-2.164zm1.956 13.505l2.182-1.256V3.624l-1.58.91-2.182 1.255v9.435zm11.581-10.95l-3.76 2.163 3.76 2.163 3.759-2.164zm-.376 4.978L16.21 7.087 14.63 6.18v4.283l2.182 1.256 1.58.908zm-8.65 9.654l5.514-3.148 2.756-1.572-3.757-2.163-4.323 2.489-3.941 2.27z"/></svg>`;
+  const LOGO_SPATIE = `<svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Spatie"><rect width="24" height="24" rx="4.8" fill="#197593"/><text x="12" y="17.5" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-weight="900" font-size="16" fill="white">S</text></svg>`;
+  const ICON_GITHUB = `<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>`;
+  const ICON_MOON = `<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/></svg>`;
+  const ICON_SUN = `<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><path stroke-linecap="round" d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>`;
+  const ICON_MENU = `<svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>`;
+
+  // Cross-page navigation only. In-page anchors (Install, Quick Start, API,
+  // etc.) live in each page's local sidebar/TOC — the navbar is for
+  // jumping BETWEEN pages, not within them.
+  const ITEMS = [
+    { label: "Home",        href: "index.html",       page: "home" },
+    { label: "URL Adapter", href: "url-adapter.html", page: "url-adapter" },
+  ];
+
+  const itemLinkClass = (item) =>
+    "t-nav-link" + (item.page === CURRENT ? " active" : "");
+
+  const desktopItems = ITEMS.map(
+    (i) => `<a href="${i.href}" class="${itemLinkClass(i)}">${i.label}</a>`,
+  ).join("");
+
+  const mobileItems = ITEMS.map(
+    (i) =>
+      `<a href="${i.href}" onclick="toggleMenu()" class="${itemLinkClass(i)} py-1">${i.label}</a>`,
+  ).join("");
+
+  const navHTML = `
+<nav class="t-nav fixed top-0 left-0 right-0 z-50 backdrop-blur">
+  <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
+    <a href="index.html" class="flex items-center gap-2 hover:opacity-90 transition-opacity">
+      ${LOGO_LARAVEL}
+      <span class="text-red-400 text-base leading-none select-none">♥</span>
+      ${LOGO_SPATIE}
+      <span class="font-bold text-sm tracking-tight t-heading">react-query-builder</span>
+    </a>
+
+    <div class="hidden md:flex items-center gap-6 text-sm">
+      ${desktopItems}
+      <a href="playground.html" class="t-nav-link font-medium text-emerald-500 hover:text-emerald-400">Playground ▶</a>
+      <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" class="t-nav-link flex items-center gap-1.5 font-medium">
+        ${ICON_GITHUB} GitHub
+      </a>
+      <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+        <span id="icon-moon">${ICON_MOON}</span>
+        <span id="icon-sun">${ICON_SUN}</span>
+      </button>
+    </div>
+
+    <div class="flex md:hidden items-center gap-2">
+      <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" class="theme-toggle" aria-label="GitHub">
+        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+      </a>
+      <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+        <span id="icon-moon-mobile">${ICON_MOON.replace('class="w-4 h-4"', 'class="w-[1.1rem] h-[1.1rem]"')}</span>
+        <span id="icon-sun-mobile" style="display:none">${ICON_SUN.replace('class="w-4 h-4"', 'class="w-[1.1rem] h-[1.1rem]"')}</span>
+      </button>
+      <button onclick="toggleMenu()" class="theme-toggle" aria-label="Menu">${ICON_MENU}</button>
+    </div>
+  </div>
+
+  <div id="mobile-menu" class="t-nav-solid md:hidden flex-col t-border-t px-6 py-4 gap-4 text-sm">
+    ${mobileItems}
+    <a href="playground.html" onclick="toggleMenu()" class="py-1 font-medium text-emerald-500">Playground ▶</a>
+  </div>
+</nav>`;
+
+  // Inject — replace the placeholder so we don't keep an extra wrapper.
+  const mount = document.getElementById("navbar");
+  if (!mount) return;
+  mount.outerHTML = navHTML;
+
+  // ─── Global handlers (attached to window so onclick="" can reach them) ───
+  window.toggleTheme = function () {
+    const html = document.documentElement;
+    const isDark = html.getAttribute("data-theme") === "dark";
+    const next = isDark ? "light" : "dark";
+    html.setAttribute("data-theme", next);
+    localStorage.setItem("theme", next);
+    const hljs = document.getElementById("hljs-theme");
+    if (hljs) hljs.href = next === "light" ? HLJS_LIGHT : HLJS_DARK;
+    const sun = document.getElementById("icon-sun-mobile");
+    const moon = document.getElementById("icon-moon-mobile");
+    if (sun) sun.style.display = next === "light" ? "block" : "none";
+    if (moon) moon.style.display = next === "dark" ? "block" : "none";
+  };
+
+  window.toggleMenu = function () {
+    const m = document.getElementById("mobile-menu");
+    if (m) m.classList.toggle("open");
+  };
+
+  window.addEventListener("resize", () => {
+    if (window.innerWidth >= 768) {
+      const m = document.getElementById("mobile-menu");
+      if (m) m.classList.remove("open");
+    }
+  });
+
+  // Sync mobile icons to the initial theme (set before paint by the page).
+  const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+  const sun = document.getElementById("icon-sun-mobile");
+  const moon = document.getElementById("icon-moon-mobile");
+  if (sun) sun.style.display = isDark ? "none" : "block";
+  if (moon) moon.style.display = isDark ? "block" : "none";
+})();

--- a/docs/assets/navbar.js
+++ b/docs/assets/navbar.js
@@ -84,9 +84,19 @@
 </nav>`;
 
   // Inject — replace the placeholder so we don't keep an extra wrapper.
+  //
+  // All inputs to `navHTML` are module-local constants (logos, labels,
+  // hrefs); `CURRENT` is only used for a boolean comparison, never
+  // interpolated into the markup. We still go through `DOMParser` instead
+  // of `outerHTML` so static analyzers (Codacy, ESLint security rules,
+  // etc.) don't have to reason about that — `DOMParser` does not execute
+  // scripts and is the conventional safe way to materialise an HTML
+  // string as nodes.
   const mount = document.getElementById("navbar");
   if (!mount) return;
-  mount.outerHTML = navHTML;
+  const parsed = new DOMParser().parseFromString(navHTML, "text/html");
+  const navEl = parsed.body.firstElementChild;
+  if (navEl) mount.replaceWith(navEl);
 
   // ─── Global handlers (attached to window so onclick="" can reach them) ───
   window.toggleTheme = function () {

--- a/docs/index.html
+++ b/docs/index.html
@@ -255,33 +255,30 @@
             font-size: 0.7rem;
             font-weight: 600;
             font-family: sans-serif;
-            background: rgba(255, 255, 255, 1);
+            background: rgba(255, 255, 255, 0.06);
             color: var(--c-text-muted);
             border: 1px solid var(--c-border-card);
             cursor: pointer;
             opacity: 1;
-            transition: opacity 0.15s, background 0.15s, color 0.15s;
+            transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
             user-select: none;
+            backdrop-filter: blur(6px);
         }
 
         [data-theme="light"] .copy-block-btn {
-            background: rgba(0, 0, 0, 1);
-        }
-
-        .copy-block:hover .copy-block-btn {
-            opacity: 1;
+            background: rgba(0, 0, 0, 0.05);
         }
 
         .copy-block-btn:hover {
-            background: rgba(52, 211, 153, 1);
+            background: rgba(52, 211, 153, 0.15);
             color: #34d399;
-            border-color: rgba(52, 211, 153, 0.3);
+            border-color: rgba(52, 211, 153, 0.4);
         }
 
         .copy-block-btn.copied {
-            background: rgba(52, 211, 153, 1);
-            color: #34d399;
-            border-color: rgba(52, 211, 153, 0.4);
+            background: #34d399;
+            color: #0a0f1a;
+            border-color: #34d399;
             opacity: 1;
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -451,76 +451,112 @@ builder.build()
 <section id="features" class="t-border-t py-14 sm:py-20 px-4 sm:px-6">
     <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-6">
 
-        <div class="card-hover t-card rounded-2xl p-6">
-            <div class="w-10 h-10 rounded-xl bg-emerald-500/15 flex items-center justify-center mb-4">
-                <svg class="w-5 h-5 text-emerald-500" fill="none" stroke="currentColor" stroke-width="2"
+        <!-- 1. URL state sync -->
+        <a href="url-adapter.html" class="card-hover t-card rounded-2xl p-6 block group">
+            <div class="w-10 h-10 rounded-xl bg-purple-500/15 flex items-center justify-center mb-4">
+                <svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" stroke-width="2"
                      viewBox="0 0 24 24">
-                    <path d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                          d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
                 </svg>
             </div>
-            <h3 class="font-bold mb-2 t-heading">Zero config, ready to use</h3>
-            <p class="t-muted text-sm leading-relaxed">Call <code class="text-emerald-400">useQueryBuilder()</code> with
-                no arguments and start chaining methods immediately. No providers, no boilerplate.</p>
-        </div>
+            <h3 class="font-bold mb-2 t-heading group-hover:text-purple-400 transition-colors">
+                Sync with the URL
+            </h3>
+            <p class="t-muted text-sm leading-relaxed">
+                Hydrate the builder from the URL on mount, push changes back as the user filters.
+                Per-bucket <code class="text-purple-400">allow</code>/<code
+                    class="text-purple-400">deny</code> lists keep crafted URLs out of your backend.
+            </p>
+        </a>
 
+        <!-- 2. Aliases -->
         <div class="card-hover t-card rounded-2xl p-6">
             <div class="w-10 h-10 rounded-xl bg-blue-500/15 flex items-center justify-center mb-4">
                 <svg class="w-5 h-5 text-blue-500" fill="none" stroke="currentColor" stroke-width="2"
                      viewBox="0 0 24 24">
-                    <path d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                          d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
                 </svg>
             </div>
-            <h3 class="font-bold mb-2 t-heading">Fully typed with TypeScript</h3>
-            <p class="t-muted text-sm leading-relaxed">Define your aliases and get autocomplete on filter names, sort
-                attributes and more. Catch typos at compile time, not in production.</p>
+            <h3 class="font-bold mb-2 t-heading">Frontend ↔ Backend aliases</h3>
+            <p class="t-muted text-sm leading-relaxed">
+                Map UI names (<code class="text-blue-400">userName</code>) to API names
+                (<code class="text-blue-400">name</code>) once. The hook,
+                <code class="text-blue-400">.build()</code> and the URL adapter translate
+                transparently.
+            </p>
         </div>
 
-        <div class="card-hover t-card rounded-2xl p-6">
-            <div class="w-10 h-10 rounded-xl bg-purple-500/15 flex items-center justify-center mb-4">
-                <svg class="w-5 h-5 text-purple-500" fill="none" stroke="currentColor" stroke-width="2"
-                     viewBox="0 0 24 24">
-                    <path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-                </svg>
-            </div>
-            <h3 class="font-bold mb-2 t-heading">React-aware, auto re-renders</h3>
-            <p class="t-muted text-sm leading-relaxed">State changes trigger component re-renders automatically. Works
-                perfectly as a <code class="text-purple-400">queryKey</code> with TanStack Query.</p>
-        </div>
-
+        <!-- 3. Conflict-aware filters -->
         <div class="card-hover t-card rounded-2xl p-6">
             <div class="w-10 h-10 rounded-xl bg-orange-500/15 flex items-center justify-center mb-4">
                 <svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" stroke-width="2"
                      viewBox="0 0 24 24">
-                    <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                          d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
                 </svg>
             </div>
             <h3 class="font-bold mb-2 t-heading">Conflict-aware filters</h3>
-            <p class="t-muted text-sm leading-relaxed">Declare mutually exclusive filters once. The library removes
-                incompatible filters automatically when you add a new one.</p>
+            <p class="t-muted text-sm leading-relaxed">
+                Declare mutually exclusive filters once
+                (<code class="text-red-400">date</code> vs
+                <code class="text-red-400">between_dates</code>). The library removes incompatible
+                ones automatically when you add a new one.
+            </p>
         </div>
 
+        <!-- 4. Operator filters -->
+        <div class="card-hover t-card rounded-2xl p-6">
+            <div class="w-10 h-10 rounded-xl bg-emerald-500/15 flex items-center justify-center mb-4">
+                <svg class="w-5 h-5 text-emerald-500" fill="none" stroke="currentColor" stroke-width="2"
+                     viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                          d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
+                </svg>
+            </div>
+            <h3 class="font-bold mb-2 t-heading">Comparison operators</h3>
+            <p class="t-muted text-sm leading-relaxed">
+                Beyond equality:
+                <code class="text-emerald-400">.filter('salary', '>', 1000)</code>,
+                less / greater / distinct, with
+                <code class="text-emerald-400">FilterOperator</code> constants for
+                type-safe autocomplete.
+            </p>
+        </div>
+
+        <!-- 5. Smart pagination -->
         <div class="card-hover t-card rounded-2xl p-6">
             <div class="w-10 h-10 rounded-xl bg-cyan-500/15 flex items-center justify-center mb-4">
                 <svg class="w-5 h-5 text-cyan-500" fill="none" stroke="currentColor" stroke-width="2"
                      viewBox="0 0 24 24">
-                    <path d="M7 21h10M12 21V3m0 0L8 7m4-4l4 4"/>
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                          d="M4 6h16M4 12h16M4 18h7"/>
                 </svg>
             </div>
             <h3 class="font-bold mb-2 t-heading">Smart pagination</h3>
-            <p class="t-muted text-sm leading-relaxed">Built-in <code class="text-cyan-400">nextPage()</code>, <code
-                    class="text-cyan-400">previousPage()</code> and auto page-reset when filters change.</p>
+            <p class="t-muted text-sm leading-relaxed">
+                <code class="text-cyan-400">nextPage()</code>,
+                <code class="text-cyan-400">previousPage()</code> and auto page-reset when filters
+                or limit change — so you never request page&nbsp;7 of nothing.
+            </p>
         </div>
 
+        <!-- 6. React-aware re-renders -->
         <div class="card-hover t-card rounded-2xl p-6">
             <div class="w-10 h-10 rounded-xl bg-pink-500/15 flex items-center justify-center mb-4">
                 <svg class="w-5 h-5 text-pink-500" fill="none" stroke="currentColor" stroke-width="2"
                      viewBox="0 0 24 24">
-                    <path d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                          d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
                 </svg>
             </div>
-            <h3 class="font-bold mb-2 t-heading">Fluent, chainable API</h3>
-            <p class="t-muted text-sm leading-relaxed">Every method returns the builder. Build complex queries in a
-                single expression, or spread them across handlers.</p>
+            <h3 class="font-bold mb-2 t-heading">React-aware re-renders</h3>
+            <p class="t-muted text-sm leading-relaxed">
+                Mutations trigger re-renders automatically.
+                <code class="text-pink-400">toArray()</code> pairs naturally with TanStack Query
+                as a <code class="text-pink-400">queryKey</code>.
+            </p>
         </div>
 
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -709,15 +709,28 @@ function UserList() {
                 <span class="w-2 h-2 rounded-full bg-gray-400"></span> Configuration
                 <a href="#api-config" class="anchor-link" title="Copy link">#</a>
             </h3>
-            <p class="t-muted text-sm mb-4">All fields are optional. Pass a config object to set initial state or
-                customize behavior.</p>
+            <p class="t-muted text-sm mb-4">All fields are optional. Pass a config object to set initial state, plug an
+                adapter, or customize behavior. The config is read <strong>once</strong> on the first render — see
+                <a href="url-adapter.html" class="text-emerald-500 hover:underline">URL Adapter</a> for the
+                <code class="text-emerald-400">adapter</code> contract in detail.</p>
             <pre><code class="language-typescript">const builder = useQueryBuilder({
   aliases: { frontend_key: 'backend_key' }, // map names transparently
+
+  // ── Initial state (all optional) ──────────────────────────────────
   filters:  [],          // pre-set filters
   includes: [],          // pre-set includes
   sorts:    [],          // pre-set sorts
   fields:   [],          // pre-set fields
   params:   {},          // extra custom params
+  pagination: { page: 1, limit: 20 },
+
+  // ── Hydrate / persist from an external source ─────────────────────
+  // The hook calls `adapter.read({ aliases })` once on the first render
+  // (lazy init, same semantics as `useState(() => …)`). If `write` is
+  // defined, it's wired as a subscriber and fires on every mutation.
+  adapter: createSearchParamsAdapter({ sync: true }),
+
+  // ── Behavior ──────────────────────────────────────────────────────
   pruneConflictingFilters: {
     date: ['between_dates'],  // mutually exclusive filters
   },
@@ -730,8 +743,13 @@ function UserList() {
     params:   null,
   },
   useQuestionMark: true,   // prepend "?" to build() output
-  pagination: { page: 1, limit: 20 },
 })</code></pre>
+
+            <p class="t-muted text-sm mt-4">
+                Explicit fields always win over what an adapter's
+                <code class="text-emerald-400">read()</code> returned, so
+                <code class="text-emerald-400">filters: [...]</code> here overrides whatever the URL had at mount time.
+            </p>
         </div>
 
         <div id="api-filters" class="mb-14">

--- a/docs/index.html
+++ b/docs/index.html
@@ -348,6 +348,7 @@
             <a href="#install" class="t-nav-link">Install</a>
             <a href="#quickstart" class="t-nav-link">Quick Start</a>
             <a href="#api" class="t-nav-link">API</a>
+            <a href="url-adapter.html" class="t-nav-link">URL Adapter</a>
             <a href="#integrations" class="t-nav-link">Integrations</a>
             <a href="playground.html" class="t-nav-link font-medium text-emerald-500 hover:text-emerald-400">Playground
                 ▶</a>
@@ -408,6 +409,7 @@
         <a href="#install" onclick="toggleMenu()" class="t-nav-link py-1">Install</a>
         <a href="#quickstart" onclick="toggleMenu()" class="t-nav-link py-1">Quick Start</a>
         <a href="#api" onclick="toggleMenu()" class="t-nav-link py-1">API Reference</a>
+        <a href="url-adapter.html" onclick="toggleMenu()" class="t-nav-link py-1">URL Adapter</a>
         <a href="#integrations" onclick="toggleMenu()" class="t-nav-link py-1">Integrations</a>
         <a href="playground.html" onclick="toggleMenu()" class="py-1 font-medium text-emerald-500">Playground ▶</a>
     </div>
@@ -571,6 +573,47 @@ builder.build()
                 single expression, or spread them across handlers.</p>
         </div>
 
+    </div>
+</section>
+
+<!-- URL ADAPTER TEASER -->
+<section class="t-border-t py-14 sm:py-20 px-4 sm:px-6">
+    <div class="max-w-5xl mx-auto">
+        <div class="t-card rounded-2xl p-6 sm:p-10" style="border:1px solid var(--c-border-card)">
+            <div class="grid md:grid-cols-[1fr_auto] gap-8 items-center">
+                <div>
+                    <div class="inline-flex items-center gap-2 bg-purple-500/10 border border-purple-500/20 rounded-full px-3 py-1 text-xs text-purple-400 font-semibold mb-4">
+                        <span class="w-1.5 h-1.5 rounded-full bg-purple-400"></span>
+                        New · URL state sync
+                    </div>
+                    <h2 class="text-xl sm:text-2xl font-bold t-heading mb-2">
+                        Hydrate the builder from the URL
+                    </h2>
+                    <p class="t-muted text-sm sm:text-base leading-relaxed mb-5">
+                        Share filtered links, deep-link to state, restore on refresh. With aliases,
+                        per-bucket allowlist / denylist, custom adapters for
+                        <code class="text-purple-400">localStorage</code> &amp; co. Read-only or two-way
+                        binding via <code class="text-purple-400">history.replaceState</code> /
+                        <code class="text-purple-400">pushState</code> / your router.
+                    </p>
+<pre class="mb-0"><code class="language-typescript">const builder = useQueryBuilder({
+  adapter: createSearchParamsAdapter({ sync: true }),
+})
+
+builder.filter("status", "active").sort("created_at", "desc")
+// URL bar: /?filter[status]=active&sort=-created_at</code></pre>
+                </div>
+                <div class="flex md:flex-col items-stretch gap-3 md:w-44">
+                    <a href="url-adapter.html" class="flex-1 inline-flex items-center justify-center gap-2 bg-purple-500 hover:bg-purple-400 text-white font-semibold rounded-xl px-4 py-2.5 text-sm transition-colors whitespace-nowrap">
+                        Read the guide
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+                    </a>
+                    <a href="playground.html" class="flex-1 inline-flex items-center justify-center gap-2 t-card font-medium rounded-xl px-4 py-2.5 text-sm t-muted transition-colors whitespace-nowrap" style="border:1px solid var(--c-border-card)">
+                        Try it live
+                    </a>
+                </div>
+            </div>
+        </div>
     </div>
 </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="dark" lang="en">
+<html data-theme="dark" data-page="home" lang="en">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -29,6 +29,7 @@
       })()
     </script>
     <script>hljs.highlightAll()</script>
+    <script src="assets/navbar.js" defer></script>
     <style>
         /* ── Theme variables ───────────────────────────────────────── */
         :root {
@@ -298,6 +299,37 @@
             color: #34d399;
         }
 
+        /* ── Home in-page TOC (floating sidebar) ───────────────────────── */
+        .home-toc {
+            position: fixed;
+            top: 5rem;
+            left: max(1rem, calc((100vw - 80rem) / 2));
+            width: 11rem;
+            z-index: 20;
+            display: none;
+        }
+        @media (min-width: 1280px) {
+            .home-toc { display: block; }
+        }
+        .home-toc p { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--c-text-faint); margin-bottom: 0.5rem; padding: 0 0.75rem; }
+        .toc-link { display: block; padding: 0.3rem 0.75rem; border-left: 2px solid transparent; color: var(--c-text-muted); font-size: 0.825rem; transition: all 0.15s; }
+        .toc-link:hover { color: var(--c-text-heading); border-left-color: var(--c-border-card); }
+        .toc-link.active { color: #34d399; border-left-color: #34d399; }
+
+        /* ── What's New banner ─────────────────────────────────────────── */
+        .whats-new-eyebrow {
+            display: inline-flex; align-items: center; gap: 0.4rem;
+            font-size: 0.7rem; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase;
+            padding: 0.3rem 0.8rem; border-radius: 9999px;
+            background: linear-gradient(135deg, rgba(250, 204, 21, 0.18), rgba(244, 114, 182, 0.18));
+            color: #facc15;
+            border: 1px solid rgba(250, 204, 21, 0.35);
+            box-shadow: 0 0 24px rgba(250, 204, 21, 0.15);
+        }
+        .whats-new-eyebrow .dot { width: 0.45rem; height: 0.45rem; border-radius: 9999px; background: #facc15; box-shadow: 0 0 8px rgba(250, 204, 21, 0.8); animation: pulse-dot 1.6s ease-in-out infinite; }
+        @keyframes pulse-dot { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.5; transform: scale(0.85); } }
+        .whats-new-title { background: linear-gradient(135deg, #facc15, #f472b6); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+
         /* Light mode: inline code accent colors readable on white */
         [data-theme="light"] code.text-emerald-400 {
             color: #059669;
@@ -319,98 +351,19 @@
 <body class="font-sans antialiased">
 
 <!-- NAV -->
-<nav class="t-nav fixed top-0 left-0 right-0 z-50 backdrop-blur">
-    <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
-        <div class="flex items-center gap-2">
-            <!-- Laravel logo (Simple Icons) -->
-            <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-                 aria-label="Laravel" fill="#FF2D20">
-                <path d="M23.642 5.43a.364.364 0 01.014.1v5.149c0 .135-.073.26-.189.326l-4.323 2.49v4.934a.378.378 0 01-.188.326L9.93 23.949a.316.316 0 01-.066.027c-.008.002-.016.008-.024.01a.348.348 0 01-.192 0c-.011-.002-.02-.008-.03-.012-.02-.008-.042-.014-.062-.025L.533 18.755a.376.376 0 01-.189-.326V2.974c0-.033.005-.066.014-.098.003-.012.01-.02.014-.032a.369.369 0 01.023-.058c.004-.013.015-.022.023-.033l.033-.045c.012-.01.025-.018.037-.027.014-.012.027-.024.041-.034H.53L5.043.05a.375.375 0 01.375 0L9.93 2.647h.002c.015.01.027.021.04.033l.038.027c.013.014.02.03.033.045.008.011.02.021.025.033.01.02.017.038.024.058.003.011.01.021.013.032.01.031.014.064.014.098v9.652l3.76-2.164V5.527c0-.033.004-.066.013-.098.003-.01.01-.02.013-.032a.487.487 0 01.024-.059c.007-.012.018-.02.025-.033.012-.015.021-.03.033-.043.012-.012.025-.02.037-.028.014-.01.026-.023.041-.032h.001l4.513-2.598a.375.375 0 01.375 0l4.513 2.598c.016.01.027.021.042.031.012.01.025.018.036.028.013.014.022.03.034.044.008.012.019.021.024.033.011.02.018.04.024.06.006.01.012.021.015.032zm-.74 5.032V6.179l-1.578.908-2.182 1.256v4.283zm-4.51 7.75v-4.287l-2.147 1.225-6.126 3.498v4.325zM1.093 3.624v14.588l8.273 4.761v-4.325l-4.322-2.445-.002-.003H5.04c-.014-.01-.025-.021-.04-.031-.011-.01-.024-.018-.035-.027l-.001-.002c-.013-.012-.021-.025-.031-.04-.01-.011-.021-.022-.028-.036h-.002c-.008-.014-.013-.031-.02-.047-.006-.016-.014-.027-.018-.043a.49.49 0 01-.008-.057c-.002-.014-.006-.027-.006-.041V5.789l-2.18-1.257zM5.23.81L1.47 2.974l3.76 2.164 3.758-2.164zm1.956 13.505l2.182-1.256V3.624l-1.58.91-2.182 1.255v9.435zm11.581-10.95l-3.76 2.163 3.76 2.163 3.759-2.164zm-.376 4.978L16.21 7.087 14.63 6.18v4.283l2.182 1.256 1.58.908zm-8.65 9.654l5.514-3.148 2.756-1.572-3.757-2.163-4.323 2.489-3.941 2.27z"/>
-            </svg>
-            <!-- Heart -->
-            <span class="text-red-400 text-base leading-none select-none">♥</span>
-            <!-- Spatie logo: white S on teal rounded square (official brand colors) -->
-            <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-                 aria-label="Spatie">
-                <rect width="24" height="24" rx="4.8" fill="#197593"/>
-                <text x="12" y="17.5" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-weight="900"
-                      font-size="16" fill="white">S
-                </text>
-            </svg>
-            <span class="font-bold text-sm tracking-tight t-heading">react-query-builder</span>
-        </div>
+<!-- NAV (shared, injected by assets/navbar.js) -->
+<div id="navbar" style="min-height:3.5rem"></div>
 
-        <!-- Desktop links -->
-        <div class="hidden md:flex items-center gap-6 text-sm">
-            <a href="#install" class="t-nav-link">Install</a>
-            <a href="#quickstart" class="t-nav-link">Quick Start</a>
-            <a href="#api" class="t-nav-link">API</a>
-            <a href="url-adapter.html" class="t-nav-link">URL Adapter</a>
-            <a href="#integrations" class="t-nav-link">Integrations</a>
-            <a href="playground.html" class="t-nav-link font-medium text-emerald-500 hover:text-emerald-400">Playground
-                ▶</a>
-            <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank"
-               class="t-nav-link flex items-center gap-1.5 font-medium">
-                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
-                </svg>
-                GitHub
-            </a>
-            <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
-                <!-- Moon (shown in dark mode) -->
-                <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
-                     viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                          d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/>
-                </svg>
-                <!-- Sun (shown in light mode) -->
-                <svg id="icon-sun" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
-                     viewBox="0 0 24 24">
-                    <circle cx="12" cy="12" r="5"/>
-                    <path stroke-linecap="round"
-                          d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
-                </svg>
-            </button>
-        </div>
-
-        <!-- Mobile: icons -->
-        <div class="flex md:hidden items-center gap-2">
-            <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" class="theme-toggle">
-                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
-                </svg>
-            </a>
-            <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
-                <svg class="w-[1.1rem] h-[1.1rem]" id="icon-moon-mobile" fill="none" stroke="currentColor"
-                     stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                          d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/>
-                </svg>
-                <svg class="w-[1.1rem] h-[1.1rem]" id="icon-sun-mobile" fill="none" stroke="currentColor"
-                     stroke-width="2" viewBox="0 0 24 24" style="display:none">
-                    <circle cx="12" cy="12" r="5"/>
-                    <path stroke-linecap="round"
-                          d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
-                </svg>
-            </button>
-            <button onclick="toggleMenu()" class="theme-toggle" aria-label="Menu">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
-                </svg>
-            </button>
-        </div>
-    </div>
-
-    <!-- Mobile menu -->
-    <div id="mobile-menu" class="t-nav-solid md:hidden flex-col t-border-t px-6 py-4 gap-4 text-sm">
-        <a href="#install" onclick="toggleMenu()" class="t-nav-link py-1">Install</a>
-        <a href="#quickstart" onclick="toggleMenu()" class="t-nav-link py-1">Quick Start</a>
-        <a href="#api" onclick="toggleMenu()" class="t-nav-link py-1">API Reference</a>
-        <a href="url-adapter.html" onclick="toggleMenu()" class="t-nav-link py-1">URL Adapter</a>
-        <a href="#integrations" onclick="toggleMenu()" class="t-nav-link py-1">Integrations</a>
-        <a href="playground.html" onclick="toggleMenu()" class="py-1 font-medium text-emerald-500">Playground ▶</a>
-    </div>
-</nav>
+<!-- In-page TOC (floating, visible on xl+ screens) -->
+<aside class="home-toc" aria-label="On this page">
+    <p>On this page</p>
+    <a href="#install"      class="toc-link">Install</a>
+    <a href="#whats-new"    class="toc-link">What's new</a>
+    <a href="#features"     class="toc-link">Features</a>
+    <a href="#quickstart"   class="toc-link">Quick Start</a>
+    <a href="#api"          class="toc-link">API Reference</a>
+    <a href="#integrations" class="toc-link">Integrations</a>
+</aside>
 
 <!-- HERO -->
 <section class="hero-glow pt-24 sm:pt-32 pb-16 sm:pb-24 px-4 sm:px-6 text-center">
@@ -495,7 +448,7 @@ builder.build()
 </section>
 
 <!-- FEATURES -->
-<section class="t-border-t py-14 sm:py-20 px-4 sm:px-6">
+<section id="features" class="t-border-t py-14 sm:py-20 px-4 sm:px-6">
     <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-6">
 
         <div class="card-hover t-card rounded-2xl p-6">
@@ -573,19 +526,29 @@ builder.build()
     </div>
 </section>
 
-<!-- URL ADAPTER TEASER -->
-<section class="t-border-t py-14 sm:py-20 px-4 sm:px-6">
+<!-- WHAT'S NEW -->
+<section id="whats-new" class="t-border-t py-14 sm:py-20 px-4 sm:px-6">
     <div class="max-w-5xl mx-auto">
+        <div class="text-center mb-10">
+            <span class="whats-new-eyebrow">
+                <span class="dot"></span>
+                Just shipped
+            </span>
+            <h2 class="text-3xl sm:text-4xl font-extrabold mt-5 mb-3 t-heading leading-tight">
+                What's new? <span class="whats-new-title block sm:inline">URL state sync.</span>
+            </h2>
+            <p class="t-muted max-w-xl mx-auto leading-relaxed">
+                Filters in the URL, just like that. Share links, deep-link to state,
+                restore on refresh — no serialization plumbing required.
+            </p>
+        </div>
+
         <div class="t-card rounded-2xl p-6 sm:p-10" style="border:1px solid var(--c-border-card)">
             <div class="grid md:grid-cols-[1fr_auto] gap-8 items-center">
                 <div>
-                    <div class="inline-flex items-center gap-2 bg-purple-500/10 border border-purple-500/20 rounded-full px-3 py-1 text-xs text-purple-400 font-semibold mb-4">
-                        <span class="w-1.5 h-1.5 rounded-full bg-purple-400"></span>
-                        New · URL state sync
-                    </div>
-                    <h2 class="text-xl sm:text-2xl font-bold t-heading mb-2">
+                    <h3 class="text-xl sm:text-2xl font-bold t-heading mb-2">
                         Hydrate the builder from the URL
-                    </h2>
+                    </h3>
                     <p class="t-muted text-sm sm:text-base leading-relaxed mb-5">
                         Share filtered links, deep-link to state, restore on refresh. With aliases,
                         per-bucket allowlist / denylist, custom adapters for
@@ -965,20 +928,8 @@ builder.filter('userName', 'John')
 </footer>
 
 <script>
-  const HLJS_DARK = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css'
-  const HLJS_LIGHT = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css'
-
-  function toggleTheme () {
-    const html = document.documentElement
-    const isDark = html.getAttribute('data-theme') === 'dark'
-    const next = isDark ? 'light' : 'dark'
-    html.setAttribute('data-theme', next)
-    localStorage.setItem('theme', next)
-    document.getElementById('hljs-theme').href = next === 'light' ? HLJS_LIGHT : HLJS_DARK
-    // sync mobile icon
-    document.getElementById('icon-sun-mobile').style.display = next === 'light' ? 'block' : 'none'
-    document.getElementById('icon-moon-mobile').style.display = next === 'dark' ? 'block' : 'none'
-  }
+  // toggleTheme(), toggleMenu() and mobile icon sync live in assets/navbar.js
+  // so they stay in step with the shared nav across pages.
 
   function copyBlock (btn) {
     const code = btn.closest('.copy-block').querySelector('code')
@@ -1000,19 +951,20 @@ builder.filter('userName', 'John')
     }, 2000)
   }
 
-  function toggleMenu () {
-    document.getElementById('mobile-menu').classList.toggle('open')
-  }
-
-  window.addEventListener('resize', () => {
-    if (window.innerWidth >= 768) document.getElementById('mobile-menu').classList.remove('open')
-  })
-
-  // Sync mobile icons to initial theme
+  // Home in-page TOC scroll-spy (only meaningful on xl+ screens where the sidebar is visible)
   ;(function () {
-    const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
-    document.getElementById('icon-sun-mobile').style.display = isDark ? 'none' : 'block'
-    document.getElementById('icon-moon-mobile').style.display = isDark ? 'block' : 'none'
+    const tocLinks = document.querySelectorAll('.home-toc .toc-link')
+    if (tocLinks.length === 0) return
+    const sections = Array.from(tocLinks)
+      .map(a => document.querySelector(a.getAttribute('href')))
+      .filter(Boolean)
+    const setActive = (id) => {
+      tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + id))
+    }
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach(e => { if (e.isIntersecting) setActive(e.target.id) })
+    }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 })
+    sections.forEach(s => obs.observe(s))
   })()
 </script>
 </body>

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -434,7 +434,13 @@
       const altNameOf = (n) => reverse.get(n) ?? forward[n] ?? n
       const filters = [], fields = [], sorts = [], includes = [], collected = {}
 
+      const pagination = {}
       for (const [key, raw] of new URLSearchParams(trimmed).entries()) {
+        if (key === 'page' || key === 'limit') {
+          const n = Number(raw)
+          if (Number.isFinite(n)) pagination[key] = n
+          continue
+        }
         const filterAttr = _bracketedKey(key, keys.filter)
         if (filterAttr !== null) {
           if (!pass('filters', filterAttr, altNameOf(filterAttr))) continue
@@ -474,6 +480,9 @@
       if (sorts.length)    result.sorts    = sorts
       if (includes.length) result.includes = includes
       if (Object.keys(collected).length) result.params = collected
+      if (pagination.page !== undefined || pagination.limit !== undefined) {
+        result.pagination = pagination
+      }
       return result
     }
     function serializeSearchParams(state, options = {}) {
@@ -520,6 +529,8 @@
         if (omit('params', k)) continue
         if (pass('params', k)) sp.append(k, v.join(','))
       }
+      if (state.pagination?.page !== undefined) sp.append('page', String(state.pagination.page))
+      if (state.pagination?.limit !== undefined) sp.append('limit', String(state.pagination.limit))
       const raw = sp.toString()
       return raw
         ? raw

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -401,21 +401,34 @@
       }
       return reverse
     }
+    function _compilePolicy(options = {}) {
+      const buckets = ['filters', 'sorts', 'includes', 'fields', 'params']
+      const allowed = {}, excluded = {}
+      for (const b of buckets) {
+        const a = options.allowed?.[b]
+        allowed[b] = a ? new Set(a) : null
+        excluded[b] = new Set(options.excludeKeys?.[b] ?? [])
+      }
+      return (bucket, ...candidates) => {
+        if (candidates.some(c => excluded[bucket].has(c))) return false
+        const allow = allowed[bucket]
+        if (allow !== null) return candidates.some(c => allow.has(c))
+        return bucket !== 'params'
+      }
+    }
     function parseSearchParams(search, options = {}) {
       const trimmed = (search ?? '').replace(/^\?/, '').trim()
       if (!trimmed) return {}
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
-      const allowed = new Set(options.allowedParams ?? [])
-      const excluded = new Set(options.excludeKeys ?? [])
+      const pass = _compilePolicy(options)
       const reverse = _reverseAliases(options.aliases)
       const aliasOf = (n) => reverse.get(n) ?? n
-      const params = new URLSearchParams(trimmed)
       const filters = [], fields = [], sorts = [], includes = [], collected = {}
 
-      for (const [key, raw] of params.entries()) {
+      for (const [key, raw] of new URLSearchParams(trimmed).entries()) {
         const filterAttr = _bracketedKey(key, keys.filter)
         if (filterAttr !== null) {
-          if (excluded.has(filterAttr)) continue
+          if (!pass('filters', filterAttr)) continue
           const { operator, rest } = _extractOperator(raw)
           filters.push({ attribute: aliasOf(filterAttr), value: rest === '' ? [] : rest.split(','), ...(operator ? { operator } : {}) })
           continue
@@ -423,29 +436,28 @@
         const fieldEntity = _bracketedKey(key, keys.fields)
         if (fieldEntity !== null) {
           for (const prop of raw.split(',')) {
-            if (excluded.has(prop) || excluded.has(`${fieldEntity}.${prop}`)) continue
-            fields.push(`${fieldEntity}.${prop}`)
+            const full = `${fieldEntity}.${prop}`
+            if (pass('fields', prop, full)) fields.push(full)
           }
           continue
         }
         if (key === keys.fields) {
-          for (const f of raw.split(',')) { if (!excluded.has(f)) fields.push(f) }
+          for (const f of raw.split(',')) { if (pass('fields', f)) fields.push(f) }
           continue
         }
         if (key === keys.sort) {
           for (const item of raw.split(',')) {
             const desc = item.startsWith('-')
             const attr = desc ? item.slice(1) : item
-            if (excluded.has(attr)) continue
-            sorts.push({ attribute: aliasOf(attr), direction: desc ? 'desc' : 'asc' })
+            if (pass('sorts', attr)) sorts.push({ attribute: aliasOf(attr), direction: desc ? 'desc' : 'asc' })
           }
           continue
         }
         if (key === keys.include) {
-          for (const inc of raw.split(',')) { if (!excluded.has(inc)) includes.push(inc) }
+          for (const inc of raw.split(',')) { if (pass('includes', inc)) includes.push(inc) }
           continue
         }
-        if (allowed.has(key) && !excluded.has(key)) collected[key] = raw.split(',')
+        if (pass('params', key)) collected[key] = raw.split(',')
       }
       const result = {}
       if (filters.length)  result.filters  = filters
@@ -457,31 +469,40 @@
     }
     function serializeSearchParams(state, options = {}) {
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
-      const allowed = new Set(options.allowedParams ?? [])
       const aliases = options.aliases ?? state.aliases
       const aliasOf = (n) => aliases?.[n] ?? n
+      const pass = _compilePolicy(options)
       const sp = new URLSearchParams()
 
       for (const f of state.filters ?? []) {
+        const wire = aliasOf(f.attribute)
+        if (!pass('filters', wire)) continue
         const op = (f.operator && f.operator !== '=') ? f.operator : ''
-        sp.append(`${keys.filter}[${aliasOf(f.attribute)}]`, op + f.value.join(','))
+        sp.append(`${keys.filter}[${wire}]`, op + f.value.join(','))
       }
       const bare = [], grouped = {}
       for (const fld of state.fields ?? []) {
         const dot = fld.indexOf('.')
-        if (dot === -1) { bare.push(fld); continue }
+        if (dot === -1) {
+          if (pass('fields', fld)) bare.push(fld)
+          continue
+        }
         const e = fld.slice(0, dot), p = fld.slice(dot + 1)
-        grouped[e] = grouped[e] ?? []; grouped[e].push(p)
+        if (pass('fields', p, fld)) (grouped[e] ??= []).push(p)
       }
       if (bare.length) sp.append(keys.fields, bare.join(','))
-      for (const [e, ps] of Object.entries(grouped)) sp.append(`${keys.fields}[${e}]`, ps.join(','))
-
-      if ((state.sorts ?? []).length) {
-        sp.append(keys.sort, state.sorts.map(s => `${s.direction === 'desc' ? '-' : ''}${aliasOf(s.attribute)}`).join(','))
+      for (const [e, ps] of Object.entries(grouped)) {
+        sp.append(`${keys.fields}[${e}]`, ps.join(','))
       }
-      if ((state.includes ?? []).length) sp.append(keys.include, state.includes.join(','))
+
+      const sortsKept = (state.sorts ?? []).filter(s => pass('sorts', aliasOf(s.attribute)))
+      if (sortsKept.length) {
+        sp.append(keys.sort, sortsKept.map(s => `${s.direction === 'desc' ? '-' : ''}${aliasOf(s.attribute)}`).join(','))
+      }
+      const includesKept = (state.includes ?? []).filter(i => pass('includes', i))
+      if (includesKept.length) sp.append(keys.include, includesKept.join(','))
       for (const [k, v] of Object.entries(state.params ?? {})) {
-        if (allowed.has(k)) sp.append(k, v.join(','))
+        if (pass('params', k)) sp.append(k, v.join(','))
       }
       const raw = sp.toString()
       return raw ? decodeURIComponent(raw) : ''
@@ -621,7 +642,7 @@ console.log('has userName:', builder.hasFilter('userName'))
 const urlAdapter = createSearchParamsAdapter({
   source: () => '?filt[status]=active&srt=-created_at&inc=user&fld[user]=id,email&locale=es',
   keys: { filter: 'filt', sort: 'srt', include: 'inc', fields: 'fld' },
-  allowedParams: ['locale'],  // anything outside this list is ignored
+  allowed: { params: ['locale'] },  // anything outside this list is ignored
 })
 
 const builder = useQueryBuilder({ adapter: urlAdapter })
@@ -648,10 +669,20 @@ console.log(builder.build())
 // Also showcases: aliases (frontend→backend round-trip) and excludeKeys
 // (denylist that drops dangerous URL injections like ?filter[is_admin]).
 const adapter = createSearchParamsAdapter({
-  source: () => '?filter[name]=John&filter[is_admin]=true&utm_source=ad',
+  source: () => '?filter[name]=John&filter[is_admin]=true&fields[user]=password,name&utm_source=ad',
   aliases: { userName: 'name' },
-  allowedParams: ['utm_source'],
-  excludeKeys: ['is_admin'],
+  // Bucket-scoped allowlist: only listed names enter; everything else is
+  // ignored. Omit a bucket → its default behavior (filters/sorts/etc. =
+  // allow-all; params = deny-all).
+  allowed: {
+    filters: ['name', 'status'],          // is_admin not listed → dropped
+    fields:  ['user.name', 'user.email'], // password not listed → dropped
+    params:  ['utm_source'],
+  },
+  // Bucket-scoped denylist: complements allowed (deny wins).
+  excludeKeys: {
+    includes: ['internal_audit_log'],
+  },
   sync: true,  // ← enables write
 })
 
@@ -813,10 +844,24 @@ interface SearchParamsAdapterOptions {
   keys?:          Partial<Record<ConfigurableURLKey, string>>;
   /** Frontend → backend attribute map. Round-trip-safe with .build(). */
   aliases?:       Record<string, string>;
-  /** Allowlist of extra query params to preserve as \`params\`. Default: []. */
-  allowedParams?: string[];
-  /** Defense-in-depth denylist. Drops matching attrs on read (overrides allowedParams). */
-  excludeKeys?:   string[];
+  /** Allowlist per bucket. When defined, only entries in the list pass
+   *  (read + write). Omit a bucket for its default behavior: filters/sorts/
+   *  includes/fields = allow-all; params = deny-all. */
+  allowed?: {
+    filters?:  string[];
+    sorts?:    string[];
+    includes?: string[];
+    fields?:   string[];
+    params?:   string[];
+  };
+  /** Defense-in-depth denylist, scoped per bucket. */
+  excludeKeys?:   {
+    filters?:  string[];
+    sorts?:    string[];
+    includes?: string[];
+    fields?:   string[];
+    params?:   string[];
+  };
   /** Provider of the query string. Default: () => window.location.search */
   source?:        () => string;
   /** Enable two-way binding: true|'replace' → replaceState, 'push' → pushState, fn → custom */

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -423,8 +423,8 @@
       if (!trimmed) return {}
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
       const pass = _compilePolicy(options)
-      const forward = options.aliases ?? {}
-      const reverse = _reverseAliases(options.aliases)
+      const forward = options.urlAliases ?? {}
+      const reverse = _reverseAliases(options.urlAliases)
       const aliasOf = (n) => reverse.get(n) ?? n
       const altNameOf = (n) => reverse.get(n) ?? forward[n] ?? n
       const filters = [], fields = [], sorts = [], includes = [], collected = {}
@@ -473,7 +473,7 @@
     }
     function serializeSearchParams(state, options = {}) {
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
-      const aliases = options.aliases ?? state.aliases
+      const aliases = options.urlAliases ?? state.aliases
       const aliasOf = (n) => aliases?.[n] ?? n
       const pass = _compilePolicy(options)
       const sp = new URLSearchParams()
@@ -520,8 +520,8 @@
       const defaultSource = () => (typeof window === 'undefined' ? '' : window.location.search)
       const adapter = {
         read: (context = {}) => {
-          const aliases = options.aliases ?? context.aliases
-          return parseSearchParams((options.source ?? defaultSource)(), { ...options, aliases })
+          const urlAliases = options.urlAliases ?? context.aliases
+          return parseSearchParams((options.source ?? defaultSource)(), { ...options, urlAliases })
         },
       }
       if (options.sync !== undefined) {
@@ -679,7 +679,8 @@ console.log(builder.build())
 // (denylist that drops dangerous URL injections like ?filter[is_admin]).
 const adapter = createSearchParamsAdapter({
   source: () => '?filter[name]=John&filter[is_admin]=true&fields[user]=password,name&utm_source=ad',
-  aliases: { userName: 'name' },
+  // urlAliases here would override; omitting it means the adapter
+  // inherits the builder's `aliases` below (URL == backend, common case).
   // Bucket-scoped allowlist: only listed names enter; everything else is
   // ignored. Omit a bucket → its default behavior (filters/sorts/etc. =
   // allow-all; params = deny-all).
@@ -851,8 +852,11 @@ type ConfigurableURLKey = 'filter' | 'sort' | 'include' | 'fields';
 interface SearchParamsAdapterOptions {
   /** Rename the URL keys the parser looks for. Defaults to identity. */
   keys?:          Partial<Record<ConfigurableURLKey, string>>;
-  /** Frontend → backend attribute map. Round-trip-safe with .build(). */
-  aliases?:       Record<string, string>;
+  /** state → URL attribute map for the URL namespace only. Independent
+   *  from BaseConfig.aliases (which is state → backend). Omit to inherit
+   *  the builder's aliases (URL == backend, common case). Set to `{}` to
+   *  opt out of any URL translation (URL == state). */
+  urlAliases?:    Record<string, string>;
   /** Allowlist per bucket. When defined, only entries in the list pass
    *  (read + write). Omit a bucket for its default behavior: filters/sorts/
    *  includes/fields = allow-all; params = deny-all. */

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -405,12 +405,14 @@
     }
     function _compilePolicy(options = {}) {
       const buckets = ['filters', 'sorts', 'includes', 'fields', 'params']
-      const allowed = {}, excluded = {}, omitted = {}
+      const allowed = {}, excluded = {}, omitted = {}, omitAll = {}
       for (const b of buckets) {
         const a = options.allowed?.[b]
         allowed[b] = a ? new Set(a) : null
         excluded[b] = new Set(options.excludeKeys?.[b] ?? [])
-        omitted[b]  = new Set(options.urlOmit?.[b] ?? [])
+        const oList = options.urlOmit?.[b] ?? []
+        omitAll[b] = oList.includes('*')
+        omitted[b] = new Set(oList.filter(x => x !== '*'))
       }
       return {
         pass: (bucket, ...candidates) => {
@@ -420,7 +422,7 @@
           return bucket !== 'params'
         },
         omit: (bucket, ...candidates) =>
-          candidates.some(c => omitted[bucket].has(c)),
+          omitAll[bucket] || candidates.some(c => omitted[bucket].has(c)),
       }
     }
     function parseSearchParams(search, options = {}) {
@@ -900,13 +902,14 @@ interface SearchParamsAdapterOptions {
   };
   /** Writer-only denylist per bucket. Listed names stay in state (so
    *  .build() still emits them to the API) but are skipped on URL write.
-   *  Use for backend-required context the user shouldn't see in the URL. */
+   *  Use for backend-required context the user shouldn't see in the URL.
+   *  Wildcard "*" drops every entry in that bucket. */
   urlOmit?:       {
-    filters?:  string[];
-    sorts?:    string[];
-    includes?: string[];
-    fields?:   string[];
-    params?:   string[];
+    filters?:  ('*' | (string & {}))[];
+    sorts?:    ('*' | (string & {}))[];
+    includes?: ('*' | (string & {}))[];
+    fields?:   ('*' | (string & {}))[];
+    params?:   ('*' | (string & {}))[];
   };
   /** Provider of the query string. Default: () => window.location.search */
   source?:        () => string;

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -703,7 +703,7 @@ console.log(builder.build())
 const adapter = createSearchParamsAdapter({
   source: () => '?filter[name]=John&filter[is_admin]=true&fields[user]=password,name&utm_source=ad',
   // urlAliases here would override; omitting it means the adapter
-  // inherits the builder's `aliases` below (URL == backend, common case).
+  // inherits the builder's aliases below (URL == backend, common case).
   // Bucket-scoped allowlist: only listed names enter; everything else is
   // ignored. Omit a bucket → its default behavior (filters/sorts/etc. =
   // allow-all; params = deny-all).
@@ -877,8 +877,8 @@ interface SearchParamsAdapterOptions {
   keys?:          Partial<Record<ConfigurableURLKey, string>>;
   /** state → URL attribute map for the URL namespace only. Independent
    *  from BaseConfig.aliases (which is state → backend). Omit to inherit
-   *  the builder's aliases (URL == backend, common case). Set to `{}` to
-   *  opt out of any URL translation (URL == state). */
+   *  the builder's aliases (URL == backend, common case). Set to an
+   *  empty object to opt out of any URL translation (URL == state). */
   urlAliases?:    Record<string, string>;
   /** Allowlist per bucket. When defined, only entries in the list pass
    *  (read + write). Omit a bucket for its default behavior: filters/sorts/

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -392,7 +392,8 @@
     }
     function _bracketedKey(paramKey, prefix) {
       if (!paramKey.startsWith(prefix + '[') || !paramKey.endsWith(']')) return null
-      return paramKey.slice(prefix.length + 1, -1)
+      const inner = paramKey.slice(prefix.length + 1, -1)
+      return inner.includes('[') || inner.includes(']') ? null : inner
     }
     function _reverseAliases(aliases) {
       const reverse = new Map()

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -505,7 +505,12 @@
         if (pass('params', k)) sp.append(k, v.join(','))
       }
       const raw = sp.toString()
-      return raw ? decodeURIComponent(raw) : ''
+      return raw
+        ? raw
+            .replace(/%5B/gi, '[').replace(/%5D/gi, ']')
+            .replace(/%2C/gi, ',')
+            .replace(/%3C/gi, '<').replace(/%3E/gi, '>').replace(/%3D/gi, '=')
+        : ''
     }
     function createSearchParamsAdapter(options = {}) {
       const defaultSource = () => (typeof window === 'undefined' ? '' : window.location.search)

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -139,6 +139,7 @@
         <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18"/></svg>
         Docs
       </a>
+      <a href="./url-adapter.html" style="color:var(--c-text-muted)" class="text-sm hover:text-white transition-colors hidden sm:inline">URL Adapter</a>
       <span style="color:var(--c-border-card)">|</span>
       <span style="color:var(--c-text-heading)" class="font-semibold text-sm">Playground</span>
       <span class="text-xs px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 font-medium">TypeScript</span>

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -122,7 +122,6 @@
     .storage-key-tag { font-family: ui-monospace, monospace; font-size: 0.7rem; padding: 0.15rem 0.5rem; border-radius: 0.3rem; border: 1px solid var(--c-border-card); color: #60a5fa; background: rgba(96,165,250,0.08); }
     .storage-btn { font-size: 0.65rem; font-weight: 600; padding: 0.2rem 0.55rem; border-radius: 0.3rem; border: 1px solid var(--c-border-card); background: transparent; color: var(--c-text-muted); cursor: pointer; transition: all 0.15s; }
     .storage-btn:hover { border-color: #34d399; color: #34d399; background: rgba(52,211,153,0.08); }
-    .storage-btn.danger:hover { border-color: #f87171; color: #f87171; background: rgba(248,113,113,0.08); }
     .storage-textarea { width: 100%; box-sizing: border-box; min-height: 6rem; font-family: ui-monospace, monospace; font-size: 0.75rem; line-height: 1.5; color: var(--c-text); background: var(--c-card); border: 1px solid var(--c-border-card); border-radius: 0.4rem; padding: 0.55rem 0.75rem; resize: vertical; outline: none; }
     .storage-textarea:focus { border-color: #34d399; }
     .storage-hint { font-size: 0.68rem; color: var(--c-text-faint); margin-top: 0.4rem; }
@@ -209,8 +208,6 @@
         <div class="storage-toolbar">
           <span class="storage-key-tag" id="storage-key-label">rqb-playground-demo</span>
           <button class="storage-btn" onclick="loadSampleStorage()">Sample</button>
-          <button class="storage-btn danger" onclick="clearStorageKey()">Clear</button>
-          <button class="storage-btn" onclick="refreshStorageInput()">Reload</button>
           <button class="storage-btn" onclick="saveStorageKey()" style="margin-left:auto;border-color:#34d399;color:#34d399">Save &amp; Run</button>
         </div>
         <textarea id="storage-input" class="storage-textarea" spellcheck="false" placeholder='{ "filters": [{ "attribute": "status", "value": ["active"] }] }'></textarea>
@@ -605,7 +602,7 @@ console.log(builder.build() || '(empty)')
 
 // Every mutation triggers write() automatically.
 builder
-  .filter('status', 'active')
+  .filter('status', 'active', true)
   .sort('updated_at', 'desc')
   .include('author')
 
@@ -1002,13 +999,6 @@ declare function useQueryBuilder(config?: BaseConfig): QueryBuilder;
       } catch (err) {
         _setFeedback('error', 'Invalid JSON: ' + err.message)
       }
-    }
-
-    function clearStorageKey() {
-      localStorage.removeItem(STORAGE_DEMO_KEY)
-      _storageInput().value = ''
-      _setFeedback('ok', 'localStorage key removed.')
-      runCode()
     }
 
     function loadSampleStorage() {

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -172,6 +172,7 @@
         <button class="example-btn" onclick="loadExample('conflicts', this)">Conflicts</button>
         <button class="example-btn" onclick="loadExample('aliases', this)">Aliases</button>
         <button class="example-btn" onclick="loadExample('urlAdapter', this)">URL Adapter</button>
+        <button class="example-btn" onclick="loadExample('urlWriter', this)">Two-way URL</button>
         <button class="example-btn" onclick="loadExample('localStorageAdapter', this)">localStorage Adapter</button>
       </div>
       <div id="monaco-container"></div>
@@ -287,7 +288,7 @@
 
     class _Builder {
       constructor(config = {}) {
-        const seeded = config.adapter?.read?.() ?? {}
+        const seeded = config.adapter?.read?.({ aliases: config.aliases }) ?? {}
         const pick = (key) => (config[key] !== undefined ? config[key] : seeded[key])
 
         this._state = {
@@ -393,36 +394,58 @@
       if (!paramKey.startsWith(prefix + '[') || !paramKey.endsWith(']')) return null
       return paramKey.slice(prefix.length + 1, -1)
     }
+    function _reverseAliases(aliases) {
+      const reverse = new Map()
+      for (const [front, back] of Object.entries(aliases ?? {})) {
+        if (!reverse.has(back)) reverse.set(back, front)
+      }
+      return reverse
+    }
     function parseSearchParams(search, options = {}) {
       const trimmed = (search ?? '').replace(/^\?/, '').trim()
       if (!trimmed) return {}
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
       const allowed = new Set(options.allowedParams ?? [])
+      const excluded = new Set(options.excludeKeys ?? [])
+      const reverse = _reverseAliases(options.aliases)
+      const aliasOf = (n) => reverse.get(n) ?? n
       const params = new URLSearchParams(trimmed)
       const filters = [], fields = [], sorts = [], includes = [], collected = {}
 
       for (const [key, raw] of params.entries()) {
         const filterAttr = _bracketedKey(key, keys.filter)
         if (filterAttr !== null) {
+          if (excluded.has(filterAttr)) continue
           const { operator, rest } = _extractOperator(raw)
-          filters.push({ attribute: filterAttr, value: rest === '' ? [] : rest.split(','), ...(operator ? { operator } : {}) })
+          filters.push({ attribute: aliasOf(filterAttr), value: rest === '' ? [] : rest.split(','), ...(operator ? { operator } : {}) })
           continue
         }
         const fieldEntity = _bracketedKey(key, keys.fields)
         if (fieldEntity !== null) {
-          for (const prop of raw.split(',')) fields.push(`${fieldEntity}.${prop}`)
-          continue
-        }
-        if (key === keys.fields) { for (const f of raw.split(',')) fields.push(f); continue }
-        if (key === keys.sort) {
-          for (const item of raw.split(',')) {
-            const desc = item.startsWith('-')
-            sorts.push({ attribute: desc ? item.slice(1) : item, direction: desc ? 'desc' : 'asc' })
+          for (const prop of raw.split(',')) {
+            if (excluded.has(prop) || excluded.has(`${fieldEntity}.${prop}`)) continue
+            fields.push(`${fieldEntity}.${prop}`)
           }
           continue
         }
-        if (key === keys.include) { for (const inc of raw.split(',')) includes.push(inc); continue }
-        if (allowed.has(key)) collected[key] = raw.split(',')
+        if (key === keys.fields) {
+          for (const f of raw.split(',')) { if (!excluded.has(f)) fields.push(f) }
+          continue
+        }
+        if (key === keys.sort) {
+          for (const item of raw.split(',')) {
+            const desc = item.startsWith('-')
+            const attr = desc ? item.slice(1) : item
+            if (excluded.has(attr)) continue
+            sorts.push({ attribute: aliasOf(attr), direction: desc ? 'desc' : 'asc' })
+          }
+          continue
+        }
+        if (key === keys.include) {
+          for (const inc of raw.split(',')) { if (!excluded.has(inc)) includes.push(inc) }
+          continue
+        }
+        if (allowed.has(key) && !excluded.has(key)) collected[key] = raw.split(',')
       }
       const result = {}
       if (filters.length)  result.filters  = filters
@@ -432,11 +455,54 @@
       if (Object.keys(collected).length) result.params = collected
       return result
     }
+    function serializeSearchParams(state, options = {}) {
+      const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
+      const allowed = new Set(options.allowedParams ?? [])
+      const aliases = options.aliases ?? state.aliases
+      const aliasOf = (n) => aliases?.[n] ?? n
+      const sp = new URLSearchParams()
+
+      for (const f of state.filters ?? []) {
+        const op = (f.operator && f.operator !== '=') ? f.operator : ''
+        sp.append(`${keys.filter}[${aliasOf(f.attribute)}]`, op + f.value.join(','))
+      }
+      const bare = [], grouped = {}
+      for (const fld of state.fields ?? []) {
+        const dot = fld.indexOf('.')
+        if (dot === -1) { bare.push(fld); continue }
+        const e = fld.slice(0, dot), p = fld.slice(dot + 1)
+        grouped[e] = grouped[e] ?? []; grouped[e].push(p)
+      }
+      if (bare.length) sp.append(keys.fields, bare.join(','))
+      for (const [e, ps] of Object.entries(grouped)) sp.append(`${keys.fields}[${e}]`, ps.join(','))
+
+      if ((state.sorts ?? []).length) {
+        sp.append(keys.sort, state.sorts.map(s => `${s.direction === 'desc' ? '-' : ''}${aliasOf(s.attribute)}`).join(','))
+      }
+      if ((state.includes ?? []).length) sp.append(keys.include, state.includes.join(','))
+      for (const [k, v] of Object.entries(state.params ?? {})) {
+        if (allowed.has(k)) sp.append(k, v.join(','))
+      }
+      const raw = sp.toString()
+      return raw ? decodeURIComponent(raw) : ''
+    }
     function createSearchParamsAdapter(options = {}) {
       const defaultSource = () => (typeof window === 'undefined' ? '' : window.location.search)
-      return {
-        read: () => parseSearchParams((options.source ?? defaultSource)(), options),
+      const adapter = {
+        read: (context = {}) => {
+          const aliases = options.aliases ?? context.aliases
+          return parseSearchParams((options.source ?? defaultSource)(), { ...options, aliases })
+        },
       }
+      if (options.sync !== undefined) {
+        adapter.write = (state) => {
+          const serialized = serializeSearchParams(state, options)
+          if (typeof options.sync === 'function') { options.sync(serialized); return }
+          // Playground stub: don't touch the real URL. Surface what would be written via console.log.
+          console.log('[adapter.write] ' + (serialized || '(empty)'))
+        }
+      }
+      return adapter
     }
 
     // ─── Examples ───────────────────────────────────────────────────────────────
@@ -572,6 +638,37 @@ builder.filter('role', 'admin').sort('name')
 console.log('\\nAfter further mutations:')
 console.log(builder.build())
 `,
+      urlWriter: `// Two-way URL adapter — read on mount + write on every mutation.
+//
+// In a real app, sync:true pushes to window.history.replaceState. The
+// playground uses a console.log stub (see runtime) so the URL bar isn't
+// touched — every "[adapter.write] ..." line below is what the URL WOULD
+// become.
+//
+// Also showcases: aliases (frontend→backend round-trip) and excludeKeys
+// (denylist that drops dangerous URL injections like ?filter[is_admin]).
+const adapter = createSearchParamsAdapter({
+  source: () => '?filter[name]=John&filter[is_admin]=true&utm_source=ad',
+  aliases: { userName: 'name' },
+  allowedParams: ['utm_source'],
+  excludeKeys: ['is_admin'],
+  sync: true,  // ← enables write
+})
+
+const builder = useQueryBuilder({
+  aliases: { userName: 'name' },  // shared with the adapter via context
+  adapter,
+})
+
+console.log('Hydrated (is_admin dropped, name → userName reversed):')
+console.log(builder.build())
+
+// Mutations trigger the writer. URL output uses BACKEND names (round-trip
+// with .build()) — userName becomes name on the wire.
+builder.filter('userName', 'Jane', true).sort('userName', 'asc')
+console.log('\\nAfter mutation, builder.build():')
+console.log(builder.build())
+`,
       localStorageAdapter: `// localStorage adapter — two-way binding with browser storage.
 // read() seeds the builder on mount; write() persists every mutation.
 //
@@ -702,8 +799,10 @@ interface GlobalState {
  * Bridge to an external source of state. \`read()\` seeds the builder once
  * at creation; the optional \`write()\` runs on every mutation.
  */
+interface AdapterReadContext { aliases?: Record<string, string>; }
+
 interface QueryBuilderAdapter {
-  read:   () => Partial<GlobalState>;
+  read:   (context?: AdapterReadContext) => Partial<GlobalState>;
   write?: (state: GlobalState) => void;
 }
 
@@ -712,10 +811,16 @@ type ConfigurableURLKey = 'filter' | 'sort' | 'include' | 'fields';
 interface SearchParamsAdapterOptions {
   /** Rename the URL keys the parser looks for. Defaults to identity. */
   keys?:          Partial<Record<ConfigurableURLKey, string>>;
+  /** Frontend → backend attribute map. Round-trip-safe with .build(). */
+  aliases?:       Record<string, string>;
   /** Allowlist of extra query params to preserve as \`params\`. Default: []. */
   allowedParams?: string[];
+  /** Defense-in-depth denylist. Drops matching attrs on read (overrides allowedParams). */
+  excludeKeys?:   string[];
   /** Provider of the query string. Default: () => window.location.search */
   source?:        () => string;
+  /** Enable two-way binding: true|'replace' → replaceState, 'push' → pushState, fn → custom */
+  sync?:          true | 'replace' | 'push' | ((search: string) => void);
 }
 
 /** Pure parser: query string → Partial<GlobalState>. No DOM needed. */
@@ -723,6 +828,12 @@ declare function parseSearchParams(
   search: string,
   options?: SearchParamsAdapterOptions,
 ): Partial<GlobalState>;
+
+/** Pure serializer: Partial<GlobalState> → query string. Inverse of parseSearchParams. */
+declare function serializeSearchParams(
+  state: Partial<GlobalState>,
+  options?: SearchParamsAdapterOptions,
+): string;
 
 /** Built-in adapter that reads window.location.search (or any \`source\`). */
 declare function createSearchParamsAdapter(
@@ -818,7 +929,7 @@ declare function useQueryBuilder(config?: BaseConfig): QueryBuilder;
 
         // Wrap in function with provided globals
         const fn = new Function(
-          'useQueryBuilder', 'FilterOperator', 'createSearchParamsAdapter', 'parseSearchParams', 'console',
+          'useQueryBuilder', 'FilterOperator', 'createSearchParamsAdapter', 'parseSearchParams', 'serializeSearchParams', 'console',
           jsCode + '\n;typeof builder !== "undefined" ? builder : null'
         )
 
@@ -827,6 +938,7 @@ declare function useQueryBuilder(config?: BaseConfig): QueryBuilder;
           FilterOperator,
           createSearchParamsAdapter,
           parseSearchParams,
+          serializeSearchParams,
           { log: (...args) => logs.push(args.map(a => formatValue(a)).join(' ')) },
         )
         _lastBuilder = result instanceof _Builder ? result : null

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -116,6 +116,19 @@
     .output-panel::-webkit-scrollbar { width: 5px; }
     .output-panel::-webkit-scrollbar-track { background: transparent; }
     .output-panel::-webkit-scrollbar-thumb { background: var(--c-border-card); border-radius: 9px; }
+
+    /* localStorage inspector */
+    .storage-toolbar { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.5rem; flex-wrap: wrap; }
+    .storage-key-tag { font-family: ui-monospace, monospace; font-size: 0.7rem; padding: 0.15rem 0.5rem; border-radius: 0.3rem; border: 1px solid var(--c-border-card); color: #60a5fa; background: rgba(96,165,250,0.08); }
+    .storage-btn { font-size: 0.65rem; font-weight: 600; padding: 0.2rem 0.55rem; border-radius: 0.3rem; border: 1px solid var(--c-border-card); background: transparent; color: var(--c-text-muted); cursor: pointer; transition: all 0.15s; }
+    .storage-btn:hover { border-color: #34d399; color: #34d399; background: rgba(52,211,153,0.08); }
+    .storage-btn.danger:hover { border-color: #f87171; color: #f87171; background: rgba(248,113,113,0.08); }
+    .storage-textarea { width: 100%; box-sizing: border-box; min-height: 6rem; font-family: ui-monospace, monospace; font-size: 0.75rem; line-height: 1.5; color: var(--c-text); background: var(--c-card); border: 1px solid var(--c-border-card); border-radius: 0.4rem; padding: 0.55rem 0.75rem; resize: vertical; outline: none; }
+    .storage-textarea:focus { border-color: #34d399; }
+    .storage-hint { font-size: 0.68rem; color: var(--c-text-faint); margin-top: 0.4rem; }
+    .storage-feedback { font-size: 0.68rem; margin-top: 0.4rem; font-family: ui-monospace, monospace; }
+    .storage-feedback.ok    { color: #34d399; }
+    .storage-feedback.error { color: #f87171; }
   </style>
 </head>
 <body>
@@ -186,9 +199,23 @@
         <div id="console-output"><span class="empty-hint">console.log() output appears here</span></div>
       </div>
 
-      <div class="output-section" style="border-bottom:none">
+      <div class="output-section">
         <div class="output-label">Builder State</div>
         <div id="state-output"><span class="empty-hint">Internal state after execution</span></div>
+      </div>
+
+      <div class="output-section" id="storage-section" style="border-bottom:none;display:none">
+        <div class="output-label">localStorage</div>
+        <div class="storage-toolbar">
+          <span class="storage-key-tag" id="storage-key-label">rqb-playground-demo</span>
+          <button class="storage-btn" onclick="loadSampleStorage()">Sample</button>
+          <button class="storage-btn danger" onclick="clearStorageKey()">Clear</button>
+          <button class="storage-btn" onclick="refreshStorageInput()">Reload</button>
+          <button class="storage-btn" onclick="saveStorageKey()" style="margin-left:auto;border-color:#34d399;color:#34d399">Save &amp; Run</button>
+        </div>
+        <textarea id="storage-input" class="storage-textarea" spellcheck="false" placeholder='{ "filters": [{ "attribute": "status", "value": ["active"] }] }'></textarea>
+        <div id="storage-feedback" class="storage-feedback"></div>
+        <div class="storage-hint">Used by the <strong>localStorage Adapter</strong> example. Edit the JSON and click <strong>Save &amp; Run</strong> to re-hydrate the builder from it. <strong>Reload</strong> refreshes from the current localStorage value.</div>
       </div>
 
     </div>
@@ -550,6 +577,9 @@ console.log(builder.build())
 `,
       localStorageAdapter: `// localStorage adapter — two-way binding with browser storage.
 // read() seeds the builder on mount; write() persists every mutation.
+//
+// TIP: there's a live editor for this key in the "localStorage" panel on the
+// right. Click "Sample" → "Save & Run" to seed it, or edit the JSON directly.
 const KEY = 'rqb-playground-demo'
 
 const localStorageAdapter = {
@@ -812,6 +842,7 @@ declare function useQueryBuilder(config?: BaseConfig): QueryBuilder;
         setStatus('error', err.message)
       } finally {
         console.log = origLog
+        refreshStorageInput({ preserveFocus: true })
       }
     }
 
@@ -907,6 +938,84 @@ declare function useQueryBuilder(config?: BaseConfig): QueryBuilder;
       document.getElementById('console-output').innerHTML = '<span class="empty-hint">No console output</span>'
     }
 
+    // ─── localStorage inspector ──────────────────────────────────────────────────
+    const STORAGE_DEMO_KEY = 'rqb-playground-demo'
+    const STORAGE_SAMPLE = {
+      filters: [
+        { attribute: 'status', value: ['active'] },
+        { attribute: 'role',   value: ['admin', 'editor'] },
+      ],
+      sorts: [{ attribute: 'created_at', direction: 'desc' }],
+      includes: ['author', 'tags'],
+      fields: ['id', 'title', 'user.name'],
+      params: {},
+    }
+
+    function _storageInput()    { return document.getElementById('storage-input') }
+    function _storageFeedback() { return document.getElementById('storage-feedback') }
+
+    function _setFeedback(kind, msg) {
+      const el = _storageFeedback()
+      el.className = 'storage-feedback ' + (kind || '')
+      el.textContent = msg || ''
+      if (kind === 'ok' && msg) {
+        clearTimeout(_setFeedback._t)
+        _setFeedback._t = setTimeout(() => {
+          if (el.textContent === msg) { el.textContent = ''; el.className = 'storage-feedback' }
+        }, 1800)
+      }
+    }
+
+    function refreshStorageInput(options) {
+      const input = _storageInput()
+      if (!input) return
+      // Don't clobber the user's edits while they're typing
+      if (options?.preserveFocus && document.activeElement === input) return
+
+      const raw = localStorage.getItem(STORAGE_DEMO_KEY)
+      if (raw === null) {
+        input.value = ''
+        return
+      }
+      try {
+        input.value = JSON.stringify(JSON.parse(raw), null, 2)
+      } catch {
+        input.value = raw // not JSON — show as-is so the user can fix it
+      }
+    }
+
+    function saveStorageKey() {
+      const input = _storageInput()
+      const raw = input.value.trim()
+      if (raw === '') {
+        localStorage.removeItem(STORAGE_DEMO_KEY)
+        _setFeedback('ok', 'Cleared (empty value).')
+        runCode()
+        return
+      }
+      try {
+        const parsed = JSON.parse(raw)
+        localStorage.setItem(STORAGE_DEMO_KEY, JSON.stringify(parsed))
+        input.value = JSON.stringify(parsed, null, 2)
+        _setFeedback('ok', 'Saved. Re-running the example…')
+        runCode()
+      } catch (err) {
+        _setFeedback('error', 'Invalid JSON: ' + err.message)
+      }
+    }
+
+    function clearStorageKey() {
+      localStorage.removeItem(STORAGE_DEMO_KEY)
+      _storageInput().value = ''
+      _setFeedback('ok', 'localStorage key removed.')
+      runCode()
+    }
+
+    function loadSampleStorage() {
+      _storageInput().value = JSON.stringify(STORAGE_SAMPLE, null, 2)
+      _setFeedback('', 'Sample loaded — click "Save & Run" to apply.')
+    }
+
     // ─── Example loader ──────────────────────────────────────────────────────────
     function loadExample(key, btn) {
       if (!editor) return
@@ -914,6 +1023,14 @@ declare function useQueryBuilder(config?: BaseConfig): QueryBuilder;
       btn.classList.add('active')
       editor.setValue(EXAMPLES[key])
       editor.setScrollPosition({ scrollTop: 0 })
+      toggleStorageSection(key === 'localStorageAdapter')
+    }
+
+    function toggleStorageSection(visible) {
+      const section = document.getElementById('storage-section')
+      if (!section) return
+      section.style.display = visible ? '' : 'none'
+      if (visible) refreshStorageInput()
     }
 
     // ─── Theme toggle ─────────────────────────────────────────────────────────────

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -159,6 +159,8 @@
         <button class="example-btn" onclick="loadExample('fields', this)">Fields & Includes</button>
         <button class="example-btn" onclick="loadExample('conflicts', this)">Conflicts</button>
         <button class="example-btn" onclick="loadExample('aliases', this)">Aliases</button>
+        <button class="example-btn" onclick="loadExample('urlAdapter', this)">URL Adapter</button>
+        <button class="example-btn" onclick="loadExample('localStorageAdapter', this)">localStorage Adapter</button>
       </div>
       <div id="monaco-container"></div>
     </div>
@@ -261,19 +263,24 @@
 
     class _Builder {
       constructor(config = {}) {
+        const seeded = config.adapter?.read?.() ?? {}
+        const pick = (key) => (config[key] !== undefined ? config[key] : seeded[key])
+
         this._state = {
-          aliases: config.aliases ?? {},
-          filters: JSON.parse(JSON.stringify(config.filters ?? [])),
-          includes: [...(config.includes ?? [])],
-          sorts: JSON.parse(JSON.stringify(config.sorts ?? [])),
-          fields: [...(config.fields ?? [])],
-          params: JSON.parse(JSON.stringify(config.params ?? {})),
+          aliases: config.aliases ?? seeded.aliases ?? {},
+          filters: JSON.parse(JSON.stringify(pick('filters') ?? [])),
+          includes: [...(pick('includes') ?? [])],
+          sorts: JSON.parse(JSON.stringify(pick('sorts') ?? [])),
+          fields: [...(pick('fields') ?? [])],
+          params: JSON.parse(JSON.stringify(pick('params') ?? {})),
           useQuestionMark: config.useQuestionMark ?? true,
           pagination: config.pagination ? { ...config.pagination } : undefined,
           pruneConflictingFilters: _reverseConflicts(config.pruneConflictingFilters ?? {}),
           delimiters: { global: ',', fields: null, filters: null, sorts: null, includes: null, params: null, ...(config.delimiters ?? {}) },
         }
+        this._writeFn = typeof config.adapter?.write === 'function' ? config.adapter.write : null
       }
+      _notifyWrite() { if (this._writeFn) this._writeFn(this._state) }
       filter(attribute, value, override) {
         if (_isOperator(value)) {
           const op = value, realValue = Array.isArray(override) ? override : [override]
@@ -329,8 +336,84 @@
       when(cond, cb)  { if (cond) cb(this._state); return this }
     }
 
+    // Wrap every mutator so adapter.write(state) is invoked on every mutation.
+    const _MUTATORS = [
+      'filter', 'removeFilter', 'clearFilters',
+      'sort', 'removeSort', 'clearSorts',
+      'fields', 'removeField', 'clearFields',
+      'include', 'removeInclude', 'clearIncludes',
+      'setParam', 'removeParam', 'clearParams',
+      'page', 'limit', 'nextPage', 'previousPage',
+    ]
+    for (const name of _MUTATORS) {
+      const original = _Builder.prototype[name]
+      _Builder.prototype[name] = function (...args) {
+        const result = original.apply(this, args)
+        this._notifyWrite()
+        return result
+      }
+    }
+
     const FilterOperator = { Equals:'=', LessThan:'<', GreaterThan:'>', LessThanOrEqual:'<=', GreaterThanOrEqual:'>=', Distinct:'<>' }
     function useQueryBuilder(config) { return new _Builder(config) }
+
+    // ─── Adapter helpers (mirror src/utils/parseSearchParams + src/adapters/searchParams) ─
+    const _OP_PREFIXES = ['<>', '<=', '>=', '<', '>']
+    function _extractOperator(raw) {
+      for (const op of _OP_PREFIXES) {
+        if (raw.startsWith(op)) return { operator: op, rest: raw.slice(op.length) }
+      }
+      return { rest: raw }
+    }
+    function _bracketedKey(paramKey, prefix) {
+      if (!paramKey.startsWith(prefix + '[') || !paramKey.endsWith(']')) return null
+      return paramKey.slice(prefix.length + 1, -1)
+    }
+    function parseSearchParams(search, options = {}) {
+      const trimmed = (search ?? '').replace(/^\?/, '').trim()
+      if (!trimmed) return {}
+      const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
+      const allowed = new Set(options.allowedParams ?? [])
+      const params = new URLSearchParams(trimmed)
+      const filters = [], fields = [], sorts = [], includes = [], collected = {}
+
+      for (const [key, raw] of params.entries()) {
+        const filterAttr = _bracketedKey(key, keys.filter)
+        if (filterAttr !== null) {
+          const { operator, rest } = _extractOperator(raw)
+          filters.push({ attribute: filterAttr, value: rest === '' ? [] : rest.split(','), ...(operator ? { operator } : {}) })
+          continue
+        }
+        const fieldEntity = _bracketedKey(key, keys.fields)
+        if (fieldEntity !== null) {
+          for (const prop of raw.split(',')) fields.push(`${fieldEntity}.${prop}`)
+          continue
+        }
+        if (key === keys.fields) { for (const f of raw.split(',')) fields.push(f); continue }
+        if (key === keys.sort) {
+          for (const item of raw.split(',')) {
+            const desc = item.startsWith('-')
+            sorts.push({ attribute: desc ? item.slice(1) : item, direction: desc ? 'desc' : 'asc' })
+          }
+          continue
+        }
+        if (key === keys.include) { for (const inc of raw.split(',')) includes.push(inc); continue }
+        if (allowed.has(key)) collected[key] = raw.split(',')
+      }
+      const result = {}
+      if (filters.length)  result.filters  = filters
+      if (fields.length)   result.fields   = fields
+      if (sorts.length)    result.sorts    = sorts
+      if (includes.length) result.includes = includes
+      if (Object.keys(collected).length) result.params = collected
+      return result
+    }
+    function createSearchParamsAdapter(options = {}) {
+      const defaultSource = () => (typeof window === 'undefined' ? '' : window.location.search)
+      return {
+        read: () => parseSearchParams((options.source ?? defaultSource)(), options),
+      }
+    }
 
     // ─── Examples ───────────────────────────────────────────────────────────────
     const EXAMPLES = {
@@ -440,6 +523,70 @@ console.log(builder.build())
 // hasFilter uses frontend names too
 console.log('has userName:', builder.hasFilter('userName'))
 `,
+      urlAdapter: `// URL adapter — hydrate the builder from a query string on first mount.
+//
+// In a real app you'd let createSearchParamsAdapter read window.location.search.
+// Here we inject a fake \`source\` so the example is reproducible inside the
+// playground (no actual URL changes).
+const urlAdapter = createSearchParamsAdapter({
+  source: () => '?filt[status]=active&srt=-created_at&inc=user&fld[user]=id,email&locale=es',
+  keys: { filter: 'filt', sort: 'srt', include: 'inc', fields: 'fld' },
+  allowedParams: ['locale'],  // anything outside this list is ignored
+})
+
+const builder = useQueryBuilder({ adapter: urlAdapter })
+
+console.log('Hydrated query string:')
+console.log(builder.build())
+// → ?filter[status]=active&fields[user]=id,email&sort=-created_at&include=user&locale=es
+
+// Output always uses the library default keys ('filter', 'sort', ...).
+// Renaming only applies when READING from the URL.
+
+// Mutations work normally — the seed is just an initial value.
+builder.filter('role', 'admin').sort('name')
+console.log('\\nAfter further mutations:')
+console.log(builder.build())
+`,
+      localStorageAdapter: `// localStorage adapter — two-way binding with browser storage.
+// read() seeds the builder on mount; write() persists every mutation.
+const KEY = 'rqb-playground-demo'
+
+const localStorageAdapter = {
+  read: () => {
+    try { return JSON.parse(localStorage.getItem(KEY) ?? '{}') }
+    catch { return {} }
+  },
+  write: (state) => {
+    localStorage.setItem(KEY, JSON.stringify({
+      filters:  state.filters,
+      sorts:    state.sorts,
+      includes: state.includes,
+      fields:   state.fields,
+      params:   state.params,
+    }))
+  },
+}
+
+const builder = useQueryBuilder({ adapter: localStorageAdapter })
+
+console.log('Seeded from localStorage on mount:')
+console.log(builder.build() || '(empty)')
+
+// Every mutation triggers write() automatically.
+builder
+  .filter('status', 'active')
+  .sort('updated_at', 'desc')
+  .include('author')
+
+console.log('\\nAfter mutations:')
+console.log(builder.build())
+
+console.log('\\nPersisted payload in localStorage:')
+console.log(JSON.parse(localStorage.getItem(KEY) ?? '{}'))
+
+// Re-run this example to see the previous state being restored.
+`,
     }
 
     // ─── Monaco setup ────────────────────────────────────────────────────────────
@@ -507,6 +654,54 @@ interface QueryBuilder {
   when(condition: boolean, callback: (state: object) => void): QueryBuilder;
 }
 
+interface GlobalState {
+  aliases:  Record<string, string>;
+  filters:  { attribute: string; value: (string|number)[]; operator?: OperatorType }[];
+  sorts:    { attribute: string; direction: Direction }[];
+  includes: string[];
+  fields:   string[];
+  params:   Record<string, (string|number)[]>;
+  pagination?: { page?: number; limit?: number };
+  useQuestionMark: boolean;
+  delimiters: {
+    global: string;
+    fields: string | null; filters: string | null; sorts: string | null;
+    includes: string | null; params: string | null;
+  };
+  pruneConflictingFilters: Record<string, string[]>;
+}
+
+/**
+ * Bridge to an external source of state. \`read()\` seeds the builder once
+ * at creation; the optional \`write()\` runs on every mutation.
+ */
+interface QueryBuilderAdapter {
+  read:   () => Partial<GlobalState>;
+  write?: (state: GlobalState) => void;
+}
+
+type ConfigurableURLKey = 'filter' | 'sort' | 'include' | 'fields';
+
+interface SearchParamsAdapterOptions {
+  /** Rename the URL keys the parser looks for. Defaults to identity. */
+  keys?:          Partial<Record<ConfigurableURLKey, string>>;
+  /** Allowlist of extra query params to preserve as \`params\`. Default: []. */
+  allowedParams?: string[];
+  /** Provider of the query string. Default: () => window.location.search */
+  source?:        () => string;
+}
+
+/** Pure parser: query string → Partial<GlobalState>. No DOM needed. */
+declare function parseSearchParams(
+  search: string,
+  options?: SearchParamsAdapterOptions,
+): Partial<GlobalState>;
+
+/** Built-in adapter that reads window.location.search (or any \`source\`). */
+declare function createSearchParamsAdapter(
+  options?: SearchParamsAdapterOptions,
+): QueryBuilderAdapter;
+
 interface BaseConfig {
   aliases?:                  Record<string, string>;
   filters?:                  { attribute: string; value: (string|number)[]; operator?: OperatorType }[];
@@ -525,6 +720,8 @@ interface BaseConfig {
   };
   useQuestionMark?: boolean;
   pagination?: { page: number; limit?: number };
+  /** Hydrate from an external source on mount; optionally persist on every change. */
+  adapter?:         QueryBuilderAdapter;
 }
 
 /** Create a new QueryBuilder instance */
@@ -594,11 +791,17 @@ declare function useQueryBuilder(config?: BaseConfig): QueryBuilder;
 
         // Wrap in function with provided globals
         const fn = new Function(
-          'useQueryBuilder', 'FilterOperator', 'console',
+          'useQueryBuilder', 'FilterOperator', 'createSearchParamsAdapter', 'parseSearchParams', 'console',
           jsCode + '\n;typeof builder !== "undefined" ? builder : null'
         )
 
-        const result = fn(useQueryBuilder, FilterOperator, { log: (...args) => logs.push(args.map(a => formatValue(a)).join(' ')) })
+        const result = fn(
+          useQueryBuilder,
+          FilterOperator,
+          createSearchParamsAdapter,
+          parseSearchParams,
+          { log: (...args) => logs.push(args.map(a => formatValue(a)).join(' ')) },
+        )
         _lastBuilder = result instanceof _Builder ? result : null
 
         renderOutput(_lastBuilder)

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -421,14 +421,16 @@
       if (!trimmed) return {}
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
       const pass = _compilePolicy(options)
+      const forward = options.aliases ?? {}
       const reverse = _reverseAliases(options.aliases)
       const aliasOf = (n) => reverse.get(n) ?? n
+      const altNameOf = (n) => reverse.get(n) ?? forward[n] ?? n
       const filters = [], fields = [], sorts = [], includes = [], collected = {}
 
       for (const [key, raw] of new URLSearchParams(trimmed).entries()) {
         const filterAttr = _bracketedKey(key, keys.filter)
         if (filterAttr !== null) {
-          if (!pass('filters', filterAttr)) continue
+          if (!pass('filters', filterAttr, altNameOf(filterAttr))) continue
           const { operator, rest } = _extractOperator(raw)
           filters.push({ attribute: aliasOf(filterAttr), value: rest === '' ? [] : rest.split(','), ...(operator ? { operator } : {}) })
           continue
@@ -449,7 +451,7 @@
           for (const item of raw.split(',')) {
             const desc = item.startsWith('-')
             const attr = desc ? item.slice(1) : item
-            if (pass('sorts', attr)) sorts.push({ attribute: aliasOf(attr), direction: desc ? 'desc' : 'asc' })
+            if (pass('sorts', attr, altNameOf(attr))) sorts.push({ attribute: aliasOf(attr), direction: desc ? 'desc' : 'asc' })
           }
           continue
         }
@@ -476,7 +478,7 @@
 
       for (const f of state.filters ?? []) {
         const wire = aliasOf(f.attribute)
-        if (!pass('filters', wire)) continue
+        if (!pass('filters', f.attribute, wire)) continue
         const op = (f.operator && f.operator !== '=') ? f.operator : ''
         sp.append(`${keys.filter}[${wire}]`, op + f.value.join(','))
       }
@@ -495,7 +497,7 @@
         sp.append(`${keys.fields}[${e}]`, ps.join(','))
       }
 
-      const sortsKept = (state.sorts ?? []).filter(s => pass('sorts', aliasOf(s.attribute)))
+      const sortsKept = (state.sorts ?? []).filter(s => pass('sorts', s.attribute, aliasOf(s.attribute)))
       if (sortsKept.length) {
         sp.append(keys.sort, sortsKept.map(s => `${s.direction === 'desc' ? '-' : ''}${aliasOf(s.attribute)}`).join(','))
       }

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -405,24 +405,29 @@
     }
     function _compilePolicy(options = {}) {
       const buckets = ['filters', 'sorts', 'includes', 'fields', 'params']
-      const allowed = {}, excluded = {}
+      const allowed = {}, excluded = {}, omitted = {}
       for (const b of buckets) {
         const a = options.allowed?.[b]
         allowed[b] = a ? new Set(a) : null
         excluded[b] = new Set(options.excludeKeys?.[b] ?? [])
+        omitted[b]  = new Set(options.urlOmit?.[b] ?? [])
       }
-      return (bucket, ...candidates) => {
-        if (candidates.some(c => excluded[bucket].has(c))) return false
-        const allow = allowed[bucket]
-        if (allow !== null) return candidates.some(c => allow.has(c))
-        return bucket !== 'params'
+      return {
+        pass: (bucket, ...candidates) => {
+          if (candidates.some(c => excluded[bucket].has(c))) return false
+          const allow = allowed[bucket]
+          if (allow !== null) return candidates.some(c => allow.has(c))
+          return bucket !== 'params'
+        },
+        omit: (bucket, ...candidates) =>
+          candidates.some(c => omitted[bucket].has(c)),
       }
     }
     function parseSearchParams(search, options = {}) {
       const trimmed = (search ?? '').replace(/^\?/, '').trim()
       if (!trimmed) return {}
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
-      const pass = _compilePolicy(options)
+      const { pass } = _compilePolicy(options)
       const forward = options.urlAliases ?? {}
       const reverse = _reverseAliases(options.urlAliases)
       const aliasOf = (n) => reverse.get(n) ?? n
@@ -475,11 +480,12 @@
       const keys = { filter: 'filter', sort: 'sort', include: 'include', fields: 'fields', ...(options.keys ?? {}) }
       const aliases = options.urlAliases ?? state.aliases
       const aliasOf = (n) => aliases?.[n] ?? n
-      const pass = _compilePolicy(options)
+      const { pass, omit } = _compilePolicy(options)
       const sp = new URLSearchParams()
 
       for (const f of state.filters ?? []) {
         const wire = aliasOf(f.attribute)
+        if (omit('filters', f.attribute, wire)) continue
         if (!pass('filters', f.attribute, wire)) continue
         const op = (f.operator && f.operator !== '=') ? f.operator : ''
         sp.append(`${keys.filter}[${wire}]`, op + f.value.join(','))
@@ -488,10 +494,12 @@
       for (const fld of state.fields ?? []) {
         const dot = fld.indexOf('.')
         if (dot === -1) {
+          if (omit('fields', fld)) continue
           if (pass('fields', fld)) bare.push(fld)
           continue
         }
         const e = fld.slice(0, dot), p = fld.slice(dot + 1)
+        if (omit('fields', p, fld)) continue
         if (pass('fields', p, fld)) (grouped[e] ??= []).push(p)
       }
       if (bare.length) sp.append(keys.fields, bare.join(','))
@@ -499,13 +507,17 @@
         sp.append(`${keys.fields}[${e}]`, ps.join(','))
       }
 
-      const sortsKept = (state.sorts ?? []).filter(s => pass('sorts', s.attribute, aliasOf(s.attribute)))
+      const sortsKept = (state.sorts ?? []).filter(s => {
+        const wire = aliasOf(s.attribute)
+        return !omit('sorts', s.attribute, wire) && pass('sorts', s.attribute, wire)
+      })
       if (sortsKept.length) {
         sp.append(keys.sort, sortsKept.map(s => `${s.direction === 'desc' ? '-' : ''}${aliasOf(s.attribute)}`).join(','))
       }
-      const includesKept = (state.includes ?? []).filter(i => pass('includes', i))
+      const includesKept = (state.includes ?? []).filter(i => !omit('includes', i) && pass('includes', i))
       if (includesKept.length) sp.append(keys.include, includesKept.join(','))
       for (const [k, v] of Object.entries(state.params ?? {})) {
+        if (omit('params', k)) continue
         if (pass('params', k)) sp.append(k, v.join(','))
       }
       const raw = sp.toString()
@@ -869,6 +881,16 @@ interface SearchParamsAdapterOptions {
   };
   /** Defense-in-depth denylist, scoped per bucket. */
   excludeKeys?:   {
+    filters?:  string[];
+    sorts?:    string[];
+    includes?: string[];
+    fields?:   string[];
+    params?:   string[];
+  };
+  /** Writer-only denylist per bucket. Listed names stay in state (so
+   *  .build() still emits them to the API) but are skipped on URL write.
+   *  Use for backend-required context the user shouldn't see in the URL. */
+  urlOmit?:       {
     filters?:  string[];
     sorts?:    string[];
     includes?: string[];

--- a/docs/url-adapter.html
+++ b/docs/url-adapter.html
@@ -1,0 +1,705 @@
+<!DOCTYPE html>
+<html data-theme="dark" lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>URL Adapter — react-query-builder</title>
+    <meta name="description"
+          content="Sync the builder state with the URL — hydrate on mount, push to history on every change, with aliases, allowlist, denylist and custom adapters."/>
+    <meta property="og:title" content="URL Adapter — @cgarciagarcia/react-query-builder"/>
+    <meta property="og:description"
+          content="Read filters/sort/include/fields from the URL and (optionally) keep the URL in sync as the builder mutates."/>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link id="hljs-theme" rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/typescript.min.js"></script>
+    <script>
+      ;(function () {
+        const saved = localStorage.getItem('theme')
+        const preferred = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+        const theme = saved || preferred
+        document.documentElement.setAttribute('data-theme', theme)
+        if (theme === 'light') {
+          document.getElementById('hljs-theme').href =
+            'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css'
+        }
+      })()
+    </script>
+    <script>hljs.highlightAll()</script>
+    <style>
+        :root {
+            --c-bg: #0a0f1a;
+            --c-nav: rgba(10, 15, 26, 0.92);
+            --c-nav-solid: #0a0f1a;
+            --c-card: #0d1117;
+            --c-code: #0d1117;
+            --c-border: rgba(255, 255, 255, 0.06);
+            --c-border-card: rgba(255, 255, 255, 0.08);
+            --c-border-input: rgba(255, 255, 255, 0.10);
+            --c-text: #e2e8f0;
+            --c-text-muted: #94a3b8;
+            --c-text-faint: #64748b;
+            --c-text-heading: #ffffff;
+            --c-shadow: rgba(0, 0, 0, 0.4);
+            --hero-glow: radial-gradient(ellipse 80% 50% at 50% -20%, rgba(168, 85, 247, 0.15), transparent);
+            --c-table-head: rgba(255, 255, 255, 0.04);
+            --c-table-row: rgba(255, 255, 255, 0.02);
+        }
+
+        [data-theme="light"] {
+            --c-bg: #f8fafc;
+            --c-nav: rgba(255, 255, 255, 0.92);
+            --c-nav-solid: #ffffff;
+            --c-card: #ffffff;
+            --c-code: #f1f5f9;
+            --c-border: rgba(0, 0, 0, 0.06);
+            --c-border-card: rgba(0, 0, 0, 0.08);
+            --c-border-input: rgba(0, 0, 0, 0.10);
+            --c-text: #334155;
+            --c-text-muted: #64748b;
+            --c-text-faint: #94a3b8;
+            --c-text-heading: #0f172a;
+            --c-shadow: rgba(0, 0, 0, 0.08);
+            --hero-glow: radial-gradient(ellipse 80% 50% at 50% -20%, rgba(168, 85, 247, 0.08), transparent);
+            --c-table-head: rgba(0, 0, 0, 0.04);
+            --c-table-row: rgba(0, 0, 0, 0.02);
+        }
+
+        html { scroll-behavior: smooth; }
+        body { background: var(--c-bg); color: var(--c-text); transition: background 0.2s, color 0.2s; }
+
+        pre { overflow-x: auto; max-width: 100%; }
+        .hljs { background: var(--c-code) !important; border-radius: 0.75rem; padding: 1rem !important; font-size: 0.8rem; line-height: 1.6; }
+        @media (min-width: 640px) { .hljs { padding: 1.25rem !important; font-size: 0.875rem; } }
+
+        .t-nav { background: var(--c-nav); border-bottom: 1px solid var(--c-border); }
+        .t-nav-solid { background: var(--c-nav-solid); }
+        .t-nav-link { color: var(--c-text-muted); transition: color 0.15s; }
+        .t-nav-link:hover { color: var(--c-text-heading); }
+        .t-nav-link.active { color: #a855f7; }
+
+        .t-card { background: var(--c-card); border: 1px solid var(--c-border-card); }
+        .t-install { background: var(--c-code); border: 1px solid var(--c-border-input); }
+        .t-border-t { border-top: 1px solid var(--c-border); }
+
+        .t-heading { color: var(--c-text-heading); }
+        .t-body { color: var(--c-text); }
+        .t-muted { color: var(--c-text-muted); }
+        .t-faint { color: var(--c-text-faint); }
+
+        .gradient-text { background: linear-gradient(135deg, #a855f7, #3b82f6); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+        .hero-glow { background: var(--hero-glow); }
+
+        .section-badge { display: inline-block; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; padding: 0.2rem 0.65rem; border-radius: 9999px; }
+
+        #mobile-menu { display: none; }
+        #mobile-menu.open { display: flex; }
+
+        .theme-toggle { width: 2rem; height: 2rem; border-radius: 0.5rem; display: flex; align-items: center; justify-content: center; transition: background 0.15s; color: var(--c-text-muted); }
+        .theme-toggle:hover { background: var(--c-border-card); color: var(--c-text-heading); }
+        #icon-sun { display: none; } #icon-moon { display: block; }
+        [data-theme="light"] #icon-sun { display: block; } [data-theme="light"] #icon-moon { display: none; }
+
+        .copy-block { position: relative; }
+        .copy-block-btn { position: absolute; top: 0.6rem; right: 0.6rem; z-index: 10; display: flex; align-items: center; gap: 0.35rem; padding: 0.25rem 0.6rem; border-radius: 0.4rem; font-size: 0.7rem; font-weight: 600; font-family: sans-serif; background: rgba(255, 255, 255, 1); color: var(--c-text-muted); border: 1px solid var(--c-border-card); cursor: pointer; opacity: 1; transition: opacity 0.15s, background 0.15s, color 0.15s; user-select: none; }
+        [data-theme="light"] .copy-block-btn { background: rgba(0, 0, 0, 1); }
+        .copy-block:hover .copy-block-btn { opacity: 1; }
+        .copy-block-btn:hover { background: rgba(168, 85, 247, 1); color: #a855f7; border-color: rgba(168, 85, 247, 0.3); }
+        .copy-block-btn.copied { background: rgba(168, 85, 247, 1); color: #a855f7; border-color: rgba(168, 85, 247, 0.4); opacity: 1; }
+
+        .anchor-link { opacity: 0; transition: opacity 0.15s; color: var(--c-text-faint); text-decoration: none; }
+        .anchor-heading:hover .anchor-link { opacity: 1; }
+        .anchor-link:hover { color: #a855f7; }
+
+        /* In-page table-of-contents */
+        .toc { position: sticky; top: 4.5rem; }
+        .toc-link { display: block; padding: 0.25rem 0.75rem; border-left: 2px solid transparent; color: var(--c-text-muted); font-size: 0.825rem; transition: all 0.15s; }
+        .toc-link:hover { color: var(--c-text-heading); border-left-color: var(--c-border-card); }
+        .toc-link.active { color: #a855f7; border-left-color: #a855f7; }
+
+        /* Diff / before-after table */
+        .compare-table { width: 100%; border-collapse: collapse; font-size: 0.825rem; border-radius: 0.75rem; overflow: hidden; border: 1px solid var(--c-border-card); }
+        .compare-table th { text-align: left; padding: 0.75rem 1rem; background: var(--c-table-head); color: var(--c-text-heading); font-weight: 600; border-bottom: 1px solid var(--c-border-card); }
+        .compare-table td { padding: 0.75rem 1rem; border-top: 1px solid var(--c-border); vertical-align: top; }
+        .compare-table tr:nth-child(odd) td { background: var(--c-table-row); }
+        .compare-table code { font-size: 0.78rem; }
+
+        /* Callout boxes */
+        .callout { border-left: 3px solid; padding: 1rem 1.25rem; border-radius: 0.5rem; background: var(--c-card); margin: 1.5rem 0; }
+        .callout-info  { border-color: #3b82f6; }
+        .callout-warn  { border-color: #f59e0b; }
+        .callout-tip   { border-color: #a855f7; }
+        .callout-title { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.5rem; }
+        .callout-info  .callout-title { color: #60a5fa; }
+        .callout-warn  .callout-title { color: #fbbf24; }
+        .callout-tip   .callout-title { color: #c084fc; }
+        .callout p:last-child { margin-bottom: 0; }
+
+        [data-theme="light"] code.text-emerald-400 { color: #059669; }
+        [data-theme="light"] code.text-purple-400 { color: #7c3aed; }
+        [data-theme="light"] code.text-cyan-400   { color: #0891b2; }
+        [data-theme="light"] code.text-red-400    { color: #dc2626; }
+        [data-theme="light"] code.text-amber-400  { color: #d97706; }
+    </style>
+</head>
+<body class="font-sans antialiased">
+
+<!-- NAV -->
+<nav class="t-nav fixed top-0 left-0 right-0 z-50 backdrop-blur">
+    <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
+        <a href="index.html" class="flex items-center gap-2 hover:opacity-90 transition-opacity">
+            <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Laravel" fill="#FF2D20">
+                <path d="M23.642 5.43a.364.364 0 01.014.1v5.149c0 .135-.073.26-.189.326l-4.323 2.49v4.934a.378.378 0 01-.188.326L9.93 23.949a.316.316 0 01-.066.027c-.008.002-.016.008-.024.01a.348.348 0 01-.192 0c-.011-.002-.02-.008-.03-.012-.02-.008-.042-.014-.062-.025L.533 18.755a.376.376 0 01-.189-.326V2.974c0-.033.005-.066.014-.098.003-.012.01-.02.014-.032a.369.369 0 01.023-.058c.004-.013.015-.022.023-.033l.033-.045c.012-.01.025-.018.037-.027.014-.012.027-.024.041-.034H.53L5.043.05a.375.375 0 01.375 0L9.93 2.647h.002c.015.01.027.021.04.033l.038.027c.013.014.02.03.033.045.008.011.02.021.025.033.01.02.017.038.024.058.003.011.01.021.013.032.01.031.014.064.014.098v9.652l3.76-2.164V5.527c0-.033.004-.066.013-.098.003-.01.01-.02.013-.032a.487.487 0 01.024-.059c.007-.012.018-.02.025-.033.012-.015.021-.03.033-.043.012-.012.025-.02.037-.028.014-.01.026-.023.041-.032h.001l4.513-2.598a.375.375 0 01.375 0l4.513 2.598c.016.01.027.021.042.031.012.01.025.018.036.028.013.014.022.03.034.044.008.012.019.021.024.033.011.02.018.04.024.06.006.01.012.021.015.032zm-.74 5.032V6.179l-1.578.908-2.182 1.256v4.283zm-4.51 7.75v-4.287l-2.147 1.225-6.126 3.498v4.325zM1.093 3.624v14.588l8.273 4.761v-4.325l-4.322-2.445-.002-.003H5.04c-.014-.01-.025-.021-.04-.031-.011-.01-.024-.018-.035-.027l-.001-.002c-.013-.012-.021-.025-.031-.04-.01-.011-.021-.022-.028-.036h-.002c-.008-.014-.013-.031-.02-.047-.006-.016-.014-.027-.018-.043a.49.49 0 01-.008-.057c-.002-.014-.006-.027-.006-.041V5.789l-2.18-1.257zM5.23.81L1.47 2.974l3.76 2.164 3.758-2.164zm1.956 13.505l2.182-1.256V3.624l-1.58.91-2.182 1.255v9.435zm11.581-10.95l-3.76 2.163 3.76 2.163 3.759-2.164zm-.376 4.978L16.21 7.087 14.63 6.18v4.283l2.182 1.256 1.58.908zm-8.65 9.654l5.514-3.148 2.756-1.572-3.757-2.163-4.323 2.489-3.941 2.27z"/>
+            </svg>
+            <span class="text-red-400 text-base leading-none select-none">♥</span>
+            <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Spatie">
+                <rect width="24" height="24" rx="4.8" fill="#197593"/>
+                <text x="12" y="17.5" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-weight="900" font-size="16" fill="white">S</text>
+            </svg>
+            <span class="font-bold text-sm tracking-tight t-heading">react-query-builder</span>
+        </a>
+
+        <div class="hidden md:flex items-center gap-6 text-sm">
+            <a href="index.html" class="t-nav-link">Home</a>
+            <a href="index.html#api" class="t-nav-link">API</a>
+            <a href="url-adapter.html" class="t-nav-link active font-medium">URL Adapter</a>
+            <a href="playground.html" class="t-nav-link font-medium text-emerald-500 hover:text-emerald-400">Playground ▶</a>
+            <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" class="t-nav-link flex items-center gap-1.5 font-medium">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+                GitHub
+            </a>
+            <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/></svg>
+                <svg id="icon-sun"  class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><path stroke-linecap="round" d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+            </button>
+        </div>
+
+        <div class="flex md:hidden items-center gap-2">
+            <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
+                <svg class="w-[1.1rem] h-[1.1rem]" id="icon-moon-mobile" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/></svg>
+                <svg class="w-[1.1rem] h-[1.1rem]" id="icon-sun-mobile" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="display:none"><circle cx="12" cy="12" r="5"/><path stroke-linecap="round" d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+            </button>
+            <button onclick="toggleMenu()" class="theme-toggle" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
+        </div>
+    </div>
+
+    <div id="mobile-menu" class="t-nav-solid md:hidden flex-col t-border-t px-6 py-4 gap-4 text-sm">
+        <a href="index.html" onclick="toggleMenu()" class="t-nav-link py-1">Home</a>
+        <a href="index.html#api" onclick="toggleMenu()" class="t-nav-link py-1">API</a>
+        <a href="url-adapter.html" onclick="toggleMenu()" class="t-nav-link active py-1 font-medium">URL Adapter</a>
+        <a href="playground.html" onclick="toggleMenu()" class="py-1 font-medium text-emerald-500">Playground ▶</a>
+        <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" onclick="toggleMenu()" class="t-nav-link py-1">GitHub</a>
+    </div>
+</nav>
+
+<!-- HERO -->
+<section class="hero-glow pt-24 sm:pt-32 pb-12 sm:pb-16 px-4 sm:px-6">
+    <div class="max-w-4xl mx-auto text-center">
+        <div class="inline-flex items-center gap-2 bg-purple-500/10 border border-purple-500/20 rounded-full px-4 py-1.5 text-sm text-purple-400 mb-6">
+            <span class="w-1.5 h-1.5 rounded-full bg-purple-400 animate-pulse"></span>
+            URL state sync
+        </div>
+
+        <h1 class="text-3xl sm:text-4xl md:text-5xl font-extrabold leading-tight mb-5 t-heading">
+            Hydrate the builder
+            <span class="gradient-text block sm:inline">from the URL</span>
+        </h1>
+
+        <p class="text-base sm:text-lg t-muted max-w-2xl mx-auto mb-10 leading-relaxed">
+            Share filtered links, deep-link to state, restore on refresh.
+            All without writing serialization or hydration logic.
+        </p>
+
+        <div class="text-left max-w-2xl mx-auto">
+<pre><code class="language-typescript">import {
+  useQueryBuilder,
+  createSearchParamsAdapter,
+} from "@cgarciagarcia/react-query-builder"
+
+const builder = useQueryBuilder({
+  adapter: createSearchParamsAdapter({ sync: true }),
+})
+
+builder.filter("status", "active").sort("created_at", "desc")
+// URL bar is now: /?filter[status]=active&sort=-created_at
+// Refresh, share, deep-link — the filters come back.</code></pre>
+        </div>
+    </div>
+</section>
+
+<!-- BODY: TOC + content -->
+<section class="t-border-t py-12 sm:py-16 px-4 sm:px-6">
+    <div class="max-w-6xl mx-auto grid lg:grid-cols-[200px_1fr] gap-10">
+
+        <!-- TOC -->
+        <aside class="hidden lg:block">
+            <nav class="toc">
+                <p class="text-xs font-bold uppercase tracking-wider t-faint mb-3 px-3">On this page</p>
+                <a href="#what" class="toc-link">What it solves</a>
+                <a href="#quickstart" class="toc-link">30-second example</a>
+                <a href="#readonly" class="toc-link">Read-only mode</a>
+                <a href="#sync" class="toc-link">Two-way binding</a>
+                <a href="#aliases" class="toc-link">Aliases</a>
+                <a href="#keys" class="toc-link">Renaming URL keys</a>
+                <a href="#policy" class="toc-link">Locking it down</a>
+                <a href="#custom" class="toc-link">Custom adapters</a>
+                <a href="#lowlevel" class="toc-link">Low-level utilities</a>
+                <a href="#limits" class="toc-link">Known limitations</a>
+            </nav>
+        </aside>
+
+        <!-- CONTENT -->
+        <article class="min-w-0 space-y-14">
+
+            <!-- WHAT -->
+            <div id="what">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    What it solves
+                    <a href="#what" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted leading-relaxed">
+                    A user picks <em>status = active</em>, sorts by date, opens page 3 — and shares
+                    the link with a teammate. You want that link to open with the exact same
+                    filters already applied. No bespoke serialization, no manual re-hydration.
+                </p>
+                <p class="t-muted leading-relaxed mt-3">
+                    That's what an <strong class="t-heading">adapter</strong> does: bridges the
+                    builder to an external source (URL, <code class="text-purple-400">localStorage</code>,
+                    anything). The built-in <code class="text-purple-400">createSearchParamsAdapter</code>
+                    handles the URL case.
+                </p>
+            </div>
+
+            <!-- QUICKSTART -->
+            <div id="quickstart">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    30-second example
+                    <a href="#quickstart" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    Pass an adapter, set <code class="text-purple-400">sync: true</code>, and you're done.
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">import {
+  useQueryBuilder,
+  createSearchParamsAdapter,
+} from "@cgarciagarcia/react-query-builder"
+
+const builder = useQueryBuilder({
+  adapter: createSearchParamsAdapter({ sync: true }),
+})
+
+builder.filter("status", "active").sort("created_at", "desc")
+// URL bar:  /?filter[status]=active&sort=-created_at</code></pre>
+                </div>
+                <p class="t-muted mt-4 text-sm leading-relaxed">
+                    What just happened:
+                </p>
+                <ul class="t-muted text-sm space-y-1.5 mt-2 list-disc list-inside leading-relaxed">
+                    <li>On mount, the adapter <strong>read</strong> the URL and seeded the builder.</li>
+                    <li><code class="text-purple-400">sync: true</code> makes it <strong>write</strong> back on every change via <code class="text-purple-400">history.replaceState</code>.</li>
+                    <li>The URL output mirrors what <code class="text-purple-400">.build()</code> emits, so backend and URL bar agree.</li>
+                </ul>
+            </div>
+
+            <!-- READ-ONLY -->
+            <div id="readonly">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Read-only mode
+                    <a href="#readonly" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    Only want to hydrate on mount and never touch the URL after? Just leave
+                    <code class="text-purple-400">sync</code> out.
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">useQueryBuilder({
+  adapter: createSearchParamsAdapter(),
+})
+// `read()` runs once at mount — same semantics as `useState(() => …)`.
+// URL changes after mount do NOT re-hydrate.</code></pre>
+                </div>
+            </div>
+
+            <!-- SYNC -->
+            <div id="sync">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Two-way binding
+                    <a href="#sync" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    <code class="text-purple-400">sync</code> accepts three forms depending on how
+                    aggressive the URL updates should be.
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">// 1) Default: replaceState — no extra history entries
+createSearchParamsAdapter({ sync: true })           // alias for "replace"
+
+// 2) pushState — every change is a back-button step
+createSearchParamsAdapter({ sync: "push" })
+
+// 3) Bring your own — Next.js / React Router / debouncing
+createSearchParamsAdapter({
+  sync: (search) => router.replace({ search }),
+})</code></pre>
+                </div>
+
+                <div class="callout callout-info mt-6">
+                    <p class="callout-title">Other apps' query params are safe</p>
+                    <p class="t-muted text-sm leading-relaxed">
+                        The writer preserves anything it doesn't recognise. So
+                        <code class="text-purple-400">?utm_source=newsletter</code> or
+                        <code class="text-purple-400">?theme=dark</code> stays untouched while your
+                        filters get added, updated, or cleared.
+                    </p>
+                </div>
+            </div>
+
+            <!-- ALIASES -->
+            <div id="aliases">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Aliases
+                    <a href="#aliases" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    You probably name things one way in the UI (<code class="text-purple-400">userName</code>,
+                    <code class="text-purple-400">createdAt</code>) and another in the API
+                    (<code class="text-purple-400">name</code>, <code class="text-purple-400">created_at</code>).
+                    Pass <code class="text-purple-400">aliases</code> to the builder and the adapter
+                    translates in <strong>both directions</strong> automatically.
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">useQueryBuilder({
+  aliases: { userName: "name", createdAt: "created_at" },
+  adapter: createSearchParamsAdapter({ sync: true }),
+})
+
+// Your code uses frontend names:
+builder.filter("userName", "Jane").sort("createdAt", "desc")
+
+// URL bar shows backend names (same as .build()):
+//   /?filter[name]=Jane&sort=-created_at
+
+// On refresh, ?filter[name]=Jane hydrates as { userName: "Jane" }.</code></pre>
+                </div>
+                <p class="t-muted mt-4 text-sm leading-relaxed">
+                    The adapter reads the aliases from the builder config automatically, so you
+                    only declare them once.
+                </p>
+            </div>
+
+            <!-- KEYS -->
+            <div id="keys">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Renaming URL keys
+                    <a href="#keys" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    The default URL can get long fast:
+                </p>
+<pre><code class="language-typescript">?filter[status]=active&filter[role]=admin&sort=-created_at&include=author,tags&fields[user]=id,name</code></pre>
+                <p class="t-muted my-4 leading-relaxed">
+                    Remap the keys to shorten it:
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">createSearchParamsAdapter({
+  keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
+  sync: true,
+})
+// → ?filt[status]=active&filt[role]=admin&srt=-created_at&inc=author,tags&fld[user]=id,name</code></pre>
+                </div>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Why you might want this:
+                </p>
+                <ul class="t-muted text-sm space-y-1.5 mt-2 list-disc list-inside leading-relaxed">
+                    <li><strong>Shorter, more shareable links</strong> — saves bytes per param.</li>
+                    <li><strong>Cleaner URL bar</strong> — easier on the eye for users and screenshots.</li>
+                    <li><strong>Brand / domain language</strong> — your app says "query", not "filter".</li>
+                    <li><strong>Collision avoidance</strong> — the surrounding app already uses <code class="text-purple-400">?filter=…</code> for something else.</li>
+                </ul>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Reader and writer use the same keys, so round-trips still work. This only
+                    affects the URL bar — <code class="text-purple-400">.build()</code> (what you
+                    pass to <code class="text-purple-400">fetch</code>) keeps using the canonical
+                    names your backend expects.
+                </p>
+            </div>
+
+            <!-- POLICY -->
+            <div id="policy">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Locking it down
+                    <a href="#policy" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-6 leading-relaxed">
+                    The URL is user input. Without limits, a crafted link like
+                    <code class="text-amber-400">?filter[is_admin]=true</code> would flow straight
+                    into your <code class="text-purple-400">.build()</code> call and out to your
+                    backend. Two primitives, <strong>per bucket</strong>, cover the two opposite
+                    needs.
+                </p>
+
+                <h3 class="text-lg font-bold mb-2 t-heading"><code class="text-purple-400">allowed</code> — strict allowlist ("only these")</h3>
+                <p class="t-muted text-sm mb-4 leading-relaxed">
+                    Use it when you have a short, explicit list of what's legitimate.
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">createSearchParamsAdapter({
+  allowed: {
+    filters: ["status", "role", "created_at"],
+    sorts:   ["created_at", "name"],
+    params:  ["locale", "tenant"],   // anything else is dropped
+  },
+})</code></pre>
+                </div>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Defaults when you omit a bucket:
+                </p>
+                <ul class="t-muted text-sm space-y-1.5 mt-2 list-disc list-inside leading-relaxed">
+                    <li><code class="text-purple-400">filters</code> / <code class="text-purple-400">sorts</code> / <code class="text-purple-400">includes</code> / <code class="text-purple-400">fields</code> → <strong>allow everything</strong> (so URL-driven filtering keeps working).</li>
+                    <li><code class="text-purple-400">params</code> → <strong>deny everything</strong> (the catch-all is deny-by-default; you must opt in by listing keys).</li>
+                </ul>
+
+                <h3 class="text-lg font-bold mb-2 mt-10 t-heading"><code class="text-purple-400">excludeKeys</code> — targeted denylist ("everything except these")</h3>
+                <p class="t-muted text-sm mb-4 leading-relaxed">
+                    Use it when you trust the bucket in general but want to block a handful of
+                    dangerous names — without enumerating everything legitimate.
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">createSearchParamsAdapter({
+  // No allowed.filters → any filter from the URL is accepted.
+  // I have 47 legitimate filter attributes and add more every month;
+  // maintaining a whitelist is brittle. But is_admin and password
+  // must NEVER come through the URL.
+  excludeKeys: {
+    filters: ["is_admin", "password"],
+  },
+})</code></pre>
+                </div>
+
+                <h3 class="text-lg font-bold mb-3 mt-10 t-heading">Which one should I use?</h3>
+                <table class="compare-table">
+                    <thead>
+                        <tr><th>Situation</th><th>Use</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>"Short, explicit list of what's allowed"</td><td><code class="text-purple-400">allowed</code></td></tr>
+                        <tr><td>"Accept everything, except these few"</td><td><code class="text-purple-400">excludeKeys</code></td></tr>
+                        <tr><td>"Whitelist plus a moving denylist on top"</td><td>both — defense in depth</td></tr>
+                    </tbody>
+                </table>
+
+                <div class="callout callout-tip mt-6">
+                    <p class="callout-title">Alias-aware on filters and sorts</p>
+                    <p class="t-muted text-sm leading-relaxed">
+                        When you set <code class="text-purple-400">aliases</code>, the policy
+                        matches if <strong>either</strong> the URL-side name (backend) OR the
+                        state-side name (frontend) is in the list. Write your rules in whichever
+                        vocabulary you think in — and listing one form on the deny side blocks
+                        both, so an attacker can't bypass by switching vocabularies.
+                    </p>
+                </div>
+
+                <p class="t-muted text-sm mt-6 leading-relaxed">
+                    A few more details:
+                </p>
+                <ul class="t-muted text-sm space-y-1.5 mt-2 list-disc list-inside leading-relaxed">
+                    <li>Both apply to the reader <strong>and</strong> the writer symmetrically — the URL bar is always inside your policy.</li>
+                    <li><code class="text-purple-400">excludeKeys</code> always wins over <code class="text-purple-400">allowed</code> (deny beats allow).</li>
+                    <li>For <code class="text-purple-400">fields</code>, match by short prop (<code class="text-purple-400">password</code>) or by <code class="text-purple-400">entity.prop</code> (<code class="text-purple-400">user.password</code>). Pick the precision you need.</li>
+                    <li><strong>Why per bucket?</strong> <code class="text-purple-400">password</code> is dangerous as a filter but fine as a <code class="text-purple-400">fields</code> selection (just picking which column the API returns). One flat list would force you into all-or-nothing.</li>
+                </ul>
+            </div>
+
+            <!-- CUSTOM ADAPTERS -->
+            <div id="custom">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Custom adapters
+                    <a href="#custom" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    <code class="text-purple-400">QueryBuilderAdapter</code> is just
+                    <code class="text-purple-400">{ read, write? }</code>. Wrap anything:
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">// Persist to localStorage instead of the URL
+const localStorageAdapter: QueryBuilderAdapter = {
+  read:  () => JSON.parse(localStorage.getItem("filters") ?? "{}"),
+  write: (state) => localStorage.setItem("filters", JSON.stringify(state)),
+}
+
+useQueryBuilder({ adapter: localStorageAdapter })</code></pre>
+                </div>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Same pattern works for <code class="text-purple-400">react-router</code> search
+                    params, hash routers, in-memory stores, IndexedDB — anything you can read
+                    from and write to.
+                </p>
+            </div>
+
+            <!-- LOW LEVEL -->
+            <div id="lowlevel">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Low-level utilities
+                    <a href="#lowlevel" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    If you only want the URL parser/serializer without the hook integration, both
+                    pieces are exported as pure functions.
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">import {
+  parseSearchParams,
+  serializeSearchParams,
+} from "@cgarciagarcia/react-query-builder"
+
+// URL → state
+parseSearchParams("?filter[status]=active&sort=-name")
+// → { filters: [...], sorts: [{ attribute: "name", direction: "desc" }] }
+
+// state → URL
+serializeSearchParams({
+  filters: [{ attribute: "status", value: ["active"] }],
+})
+// → "filter[status]=active"</code></pre>
+                </div>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Both accept the same <code class="text-purple-400">keys</code> /
+                    <code class="text-purple-400">aliases</code> /
+                    <code class="text-purple-400">allowed</code> /
+                    <code class="text-purple-400">excludeKeys</code> options as the adapter, plus an
+                    optional pre-compiled <code class="text-purple-400">PolicyGate</code> as the
+                    third argument for the very perf-conscious.
+                </p>
+            </div>
+
+            <!-- LIMITATIONS -->
+            <div id="limits">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Known limitations
+                    <a href="#limits" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    The URL protocol uses a few characters as control symbols. Filter values
+                    containing them <strong>silently corrupt</strong> on round-trip — the writer
+                    emits the value, but the reader splits it differently. Until we lift this
+                    limitation, treat these as off-limits inside filter values:
+                </p>
+                <table class="compare-table">
+                    <thead>
+                        <tr><th>Character</th><th>Why it breaks</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td><code class="text-amber-400">,</code></td><td>Multi-value separator — <code class="text-purple-400">filter[tag]=a,b</code> becomes <code class="text-purple-400">["a", "b"]</code> on parse.</td></tr>
+                        <tr><td><code class="text-amber-400">&lt;</code>, <code class="text-amber-400">&gt;</code>, <code class="text-amber-400">&lt;=</code>, <code class="text-amber-400">&gt;=</code>, <code class="text-amber-400">&lt;&gt;</code> (leading)</td><td>Operator syntax — <code class="text-purple-400">filter[age]=&gt;=18</code> becomes operator <code class="text-purple-400">&gt;=</code> + value <code class="text-purple-400">["18"]</code>.</td></tr>
+                    </tbody>
+                </table>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Other "special-looking" characters like <code class="text-purple-400">%</code>,
+                    <code class="text-purple-400">&amp;</code>, <code class="text-purple-400">+</code>
+                    and spaces are fine — they travel URL-escaped and survive the round-trip
+                    intact.
+                </p>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    If you need any of these inside a value (e.g. tags with commas), keep that
+                    piece of state outside the URL adapter, or escape it on your side before
+                    passing it to <code class="text-purple-400">.filter()</code>.
+                </p>
+            </div>
+
+            <!-- CTA -->
+            <div class="t-card rounded-2xl p-8 text-center mt-8" style="border:1px solid var(--c-border-card)">
+                <p class="text-lg font-bold t-heading mb-3">Try it live</p>
+                <p class="t-muted text-sm mb-5 leading-relaxed max-w-md mx-auto">
+                    The playground has dedicated examples for the URL adapter, two-way sync, and a localStorage adapter.
+                </p>
+                <a href="playground.html" class="inline-flex items-center gap-2 bg-purple-500 hover:bg-purple-400 text-white font-semibold rounded-xl px-5 py-2.5 text-sm transition-colors">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polygon points="5,3 19,12 5,21"/></svg>
+                    Open Playground
+                </a>
+            </div>
+
+        </article>
+    </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="t-border-t py-14 px-6 text-center text-sm t-faint">
+    <div class="max-w-4xl mx-auto">
+        <p class="t-heading font-bold text-base mb-1">@cgarciagarcia/react-query-builder</p>
+        <p class="mb-6 t-muted">MIT License · Made by <a href="https://github.com/cgarciagarcia" target="_blank" class="text-emerald-500 hover:underline">Carlos Garcia</a></p>
+        <div class="flex flex-wrap justify-center gap-6 text-sm t-muted">
+            <a href="index.html" class="hover:text-emerald-500 transition-colors">Home</a>
+            <a href="playground.html" class="hover:text-emerald-500 transition-colors">Playground</a>
+            <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" class="hover:text-emerald-500 transition-colors">GitHub</a>
+            <a href="https://www.npmjs.com/package/@cgarciagarcia/react-query-builder" target="_blank" class="hover:text-emerald-500 transition-colors">npm</a>
+            <a href="https://github.com/cgarciagarcia/react-query-builder/discussions" target="_blank" class="hover:text-emerald-500 transition-colors">Discussions</a>
+        </div>
+    </div>
+</footer>
+
+<script>
+  const HLJS_DARK  = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css'
+  const HLJS_LIGHT = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css'
+
+  function toggleTheme () {
+    const html = document.documentElement
+    const isDark = html.getAttribute('data-theme') === 'dark'
+    const next = isDark ? 'light' : 'dark'
+    html.setAttribute('data-theme', next)
+    localStorage.setItem('theme', next)
+    document.getElementById('hljs-theme').href = next === 'light' ? HLJS_LIGHT : HLJS_DARK
+    document.getElementById('icon-sun-mobile').style.display  = next === 'light' ? 'block' : 'none'
+    document.getElementById('icon-moon-mobile').style.display = next === 'dark'  ? 'block' : 'none'
+  }
+
+  function copyBlock (btn) {
+    const code = btn.closest('.copy-block').querySelector('code')
+    navigator.clipboard.writeText(code.innerText)
+    btn.classList.add('copied')
+    btn.innerHTML = '<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg> Copied!'
+    setTimeout(() => {
+      btn.classList.remove('copied')
+      btn.innerHTML = '<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> Copy'
+    }, 2000)
+  }
+
+  function toggleMenu () { document.getElementById('mobile-menu').classList.toggle('open') }
+  window.addEventListener('resize', () => {
+    if (window.innerWidth >= 768) document.getElementById('mobile-menu').classList.remove('open')
+  })
+
+  // Sync mobile icons to initial theme
+  ;(function () {
+    const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
+    document.getElementById('icon-sun-mobile').style.display  = isDark ? 'none'  : 'block'
+    document.getElementById('icon-moon-mobile').style.display = isDark ? 'block' : 'none'
+  })()
+
+  // TOC scroll-spy
+  ;(function () {
+    const tocLinks = document.querySelectorAll('.toc-link')
+    const sections = Array.from(tocLinks).map(a => document.querySelector(a.getAttribute('href')))
+    const setActive = (id) => {
+      tocLinks.forEach(a => a.classList.toggle('active', a.getAttribute('href') === '#' + id))
+    }
+    const obs = new IntersectionObserver((entries) => {
+      entries.forEach(e => { if (e.isIntersecting) setActive(e.target.id) })
+    }, { rootMargin: '-30% 0px -60% 0px', threshold: 0 })
+    sections.forEach(s => s && obs.observe(s))
+  })()
+</script>
+</body>
+</html>

--- a/docs/url-adapter.html
+++ b/docs/url-adapter.html
@@ -475,6 +475,21 @@ builder.filter("status", "active")
                     <code class="text-purple-400">sorts</code> — list a name in either
                     vocabulary (state or URL) and both forms are skipped.
                 </p>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    <strong>Wildcard <code class="text-purple-400">"*"</code></strong> drops every
+                    entry in that bucket. Most common use: hide all
+                    <code class="text-purple-400">fields</code> from the URL, since they're an
+                    internal API optimisation the user rarely cares about. IDE autocomplete
+                    surfaces <code class="text-purple-400">"*"</code> via a literal-union typing
+                    trick.
+                </p>
+<pre class="mt-3"><code class="language-typescript">adapter: createSearchParamsAdapter({
+  sync: true,
+  urlOmit: {
+    fields:   ["*"],                              // hide ALL fields
+    includes: ["organization", "permissions"],    // hide only these
+  },
+})</code></pre>
                 <div class="callout callout-warn mt-4">
                     <p class="callout-title">Reader is not affected</p>
                     <p class="t-muted text-sm leading-relaxed">

--- a/docs/url-adapter.html
+++ b/docs/url-adapter.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="dark" lang="en">
+<html data-theme="dark" data-page="url-adapter" lang="en">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -27,6 +27,7 @@
       })()
     </script>
     <script>hljs.highlightAll()</script>
+    <script src="assets/navbar.js" defer></script>
     <style>
         :root {
             --c-bg: #0a0f1a;
@@ -166,54 +167,8 @@
 <body class="font-sans antialiased">
 
 <!-- NAV -->
-<nav class="t-nav fixed top-0 left-0 right-0 z-50 backdrop-blur">
-    <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
-        <a href="index.html" class="flex items-center gap-2 hover:opacity-90 transition-opacity">
-            <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Laravel" fill="#FF2D20">
-                <path d="M23.642 5.43a.364.364 0 01.014.1v5.149c0 .135-.073.26-.189.326l-4.323 2.49v4.934a.378.378 0 01-.188.326L9.93 23.949a.316.316 0 01-.066.027c-.008.002-.016.008-.024.01a.348.348 0 01-.192 0c-.011-.002-.02-.008-.03-.012-.02-.008-.042-.014-.062-.025L.533 18.755a.376.376 0 01-.189-.326V2.974c0-.033.005-.066.014-.098.003-.012.01-.02.014-.032a.369.369 0 01.023-.058c.004-.013.015-.022.023-.033l.033-.045c.012-.01.025-.018.037-.027.014-.012.027-.024.041-.034H.53L5.043.05a.375.375 0 01.375 0L9.93 2.647h.002c.015.01.027.021.04.033l.038.027c.013.014.02.03.033.045.008.011.02.021.025.033.01.02.017.038.024.058.003.011.01.021.013.032.01.031.014.064.014.098v9.652l3.76-2.164V5.527c0-.033.004-.066.013-.098.003-.01.01-.02.013-.032a.487.487 0 01.024-.059c.007-.012.018-.02.025-.033.012-.015.021-.03.033-.043.012-.012.025-.02.037-.028.014-.01.026-.023.041-.032h.001l4.513-2.598a.375.375 0 01.375 0l4.513 2.598c.016.01.027.021.042.031.012.01.025.018.036.028.013.014.022.03.034.044.008.012.019.021.024.033.011.02.018.04.024.06.006.01.012.021.015.032zm-.74 5.032V6.179l-1.578.908-2.182 1.256v4.283zm-4.51 7.75v-4.287l-2.147 1.225-6.126 3.498v4.325zM1.093 3.624v14.588l8.273 4.761v-4.325l-4.322-2.445-.002-.003H5.04c-.014-.01-.025-.021-.04-.031-.011-.01-.024-.018-.035-.027l-.001-.002c-.013-.012-.021-.025-.031-.04-.01-.011-.021-.022-.028-.036h-.002c-.008-.014-.013-.031-.02-.047-.006-.016-.014-.027-.018-.043a.49.49 0 01-.008-.057c-.002-.014-.006-.027-.006-.041V5.789l-2.18-1.257zM5.23.81L1.47 2.974l3.76 2.164 3.758-2.164zm1.956 13.505l2.182-1.256V3.624l-1.58.91-2.182 1.255v9.435zm11.581-10.95l-3.76 2.163 3.76 2.163 3.759-2.164zm-.376 4.978L16.21 7.087 14.63 6.18v4.283l2.182 1.256 1.58.908zm-8.65 9.654l5.514-3.148 2.756-1.572-3.757-2.163-4.323 2.489-3.941 2.27z"/>
-            </svg>
-            <span class="text-red-400 text-base leading-none select-none">♥</span>
-            <svg class="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-label="Spatie">
-                <rect width="24" height="24" rx="4.8" fill="#197593"/>
-                <text x="12" y="17.5" text-anchor="middle" font-family="Arial,Helvetica,sans-serif" font-weight="900" font-size="16" fill="white">S</text>
-            </svg>
-            <span class="font-bold text-sm tracking-tight t-heading">react-query-builder</span>
-        </a>
-
-        <div class="hidden md:flex items-center gap-6 text-sm">
-            <a href="index.html" class="t-nav-link">Home</a>
-            <a href="index.html#api" class="t-nav-link">API</a>
-            <a href="url-adapter.html" class="t-nav-link active font-medium">URL Adapter</a>
-            <a href="playground.html" class="t-nav-link font-medium text-emerald-500 hover:text-emerald-400">Playground ▶</a>
-            <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" class="t-nav-link flex items-center gap-1.5 font-medium">
-                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-                GitHub
-            </a>
-            <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
-                <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/></svg>
-                <svg id="icon-sun"  class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><path stroke-linecap="round" d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
-            </button>
-        </div>
-
-        <div class="flex md:hidden items-center gap-2">
-            <button onclick="toggleTheme()" class="theme-toggle" aria-label="Toggle theme">
-                <svg class="w-[1.1rem] h-[1.1rem]" id="icon-moon-mobile" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/></svg>
-                <svg class="w-[1.1rem] h-[1.1rem]" id="icon-sun-mobile" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" style="display:none"><circle cx="12" cy="12" r="5"/><path stroke-linecap="round" d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
-            </button>
-            <button onclick="toggleMenu()" class="theme-toggle" aria-label="Menu">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
-            </button>
-        </div>
-    </div>
-
-    <div id="mobile-menu" class="t-nav-solid md:hidden flex-col t-border-t px-6 py-4 gap-4 text-sm">
-        <a href="index.html" onclick="toggleMenu()" class="t-nav-link py-1">Home</a>
-        <a href="index.html#api" onclick="toggleMenu()" class="t-nav-link py-1">API</a>
-        <a href="url-adapter.html" onclick="toggleMenu()" class="t-nav-link active py-1 font-medium">URL Adapter</a>
-        <a href="playground.html" onclick="toggleMenu()" class="py-1 font-medium text-emerald-500">Playground ▶</a>
-        <a href="https://github.com/cgarciagarcia/react-query-builder" target="_blank" onclick="toggleMenu()" class="t-nav-link py-1">GitHub</a>
-    </div>
-</nav>
+<!-- NAV (shared, injected by assets/navbar.js) -->
+<div id="navbar" style="min-height:3.5rem"></div>
 
 <!-- HERO -->
 <section class="hero-glow pt-24 sm:pt-32 pb-12 sm:pb-16 px-4 sm:px-6">
@@ -671,19 +626,8 @@ serializeSearchParams({
 </footer>
 
 <script>
-  const HLJS_DARK  = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css'
-  const HLJS_LIGHT = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css'
-
-  function toggleTheme () {
-    const html = document.documentElement
-    const isDark = html.getAttribute('data-theme') === 'dark'
-    const next = isDark ? 'light' : 'dark'
-    html.setAttribute('data-theme', next)
-    localStorage.setItem('theme', next)
-    document.getElementById('hljs-theme').href = next === 'light' ? HLJS_LIGHT : HLJS_DARK
-    document.getElementById('icon-sun-mobile').style.display  = next === 'light' ? 'block' : 'none'
-    document.getElementById('icon-moon-mobile').style.display = next === 'dark'  ? 'block' : 'none'
-  }
+  // toggleTheme(), toggleMenu() and mobile icon sync live in assets/navbar.js
+  // so they stay in step with the shared nav across pages.
 
   function copyBlock (btn) {
     const code = btn.closest('.copy-block').querySelector('code')
@@ -695,18 +639,6 @@ serializeSearchParams({
       btn.innerHTML = '<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg> Copy'
     }, 2000)
   }
-
-  function toggleMenu () { document.getElementById('mobile-menu').classList.toggle('open') }
-  window.addEventListener('resize', () => {
-    if (window.innerWidth >= 768) document.getElementById('mobile-menu').classList.remove('open')
-  })
-
-  // Sync mobile icons to initial theme
-  ;(function () {
-    const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
-    document.getElementById('icon-sun-mobile').style.display  = isDark ? 'none'  : 'block'
-    document.getElementById('icon-moon-mobile').style.display = isDark ? 'block' : 'none'
-  })()
 
   // TOC scroll-spy
   ;(function () {

--- a/docs/url-adapter.html
+++ b/docs/url-adapter.html
@@ -218,6 +218,7 @@ builder.filter("status", "active").sort("created_at", "desc")
                 <a href="#readonly" class="toc-link">Read-only mode</a>
                 <a href="#sync" class="toc-link">Two-way binding</a>
                 <a href="#aliases" class="toc-link">Aliases</a>
+                <a href="#omit" class="toc-link">Hide from URL</a>
                 <a href="#keys" class="toc-link">Renaming URL keys</a>
                 <a href="#policy" class="toc-link">Locking it down</a>
                 <a href="#custom" class="toc-link">Custom adapters</a>
@@ -423,6 +424,51 @@ builder.filter("dni", "12345").filter("rol", "admin")
   urlAliases: { dni: "documento", rol: "type" },
   allowed: { filters: ["documento", "type"] },   // backend-name attempts → dropped
 })</code></pre>
+                </div>
+            </div>
+
+            <!-- URL OMIT -->
+            <div id="omit">
+                <h2 class="text-2xl font-bold mb-3 flex items-center gap-2 t-heading anchor-heading">
+                    Hide noisy state from the URL
+                    <a href="#omit" class="anchor-link">#</a>
+                </h2>
+                <p class="t-muted mb-4 leading-relaxed">
+                    Sometimes the builder carries entries your backend needs but the user
+                    shouldn't see in the URL bar — typical case: default
+                    <code class="text-purple-400">include</code>s the API always requires
+                    (<code class="text-purple-400">organization</code>,
+                    <code class="text-purple-400">permissions</code>) that just clutter
+                    shareable links. <code class="text-purple-400">urlOmit</code> is a
+                    writer-only denylist per bucket:
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">useQueryBuilder({
+  includes: ["organization", "permissions"],   // always sent to API
+  adapter: createSearchParamsAdapter({
+    sync: true,
+    urlOmit: { includes: ["organization", "permissions"] },
+  }),
+})
+
+builder.filter("status", "active")
+// .build() → ?filter[status]=active&include=organization,permissions   ← backend gets them
+// URL bar   → ?filter[status]=active                                    ← user sees only this</code></pre>
+                </div>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Alias-aware on <code class="text-purple-400">filters</code> and
+                    <code class="text-purple-400">sorts</code> — list a name in either
+                    vocabulary (state or URL) and both forms are skipped.
+                </p>
+                <div class="callout callout-warn mt-4">
+                    <p class="callout-title">Reader is not affected</p>
+                    <p class="t-muted text-sm leading-relaxed">
+                        <code class="text-amber-400">urlOmit</code> only skips on write.
+                        If a crafted URL contains one of these names, the reader still
+                        processes it. Add the same names to <code class="text-amber-400">excludeKeys</code>
+                        if you also want to refuse them on hydration.
+                    </p>
                 </div>
             </div>
 

--- a/docs/url-adapter.html
+++ b/docs/url-adapter.html
@@ -102,11 +102,31 @@
         [data-theme="light"] #icon-sun { display: block; } [data-theme="light"] #icon-moon { display: none; }
 
         .copy-block { position: relative; }
-        .copy-block-btn { position: absolute; top: 0.6rem; right: 0.6rem; z-index: 10; display: flex; align-items: center; gap: 0.35rem; padding: 0.25rem 0.6rem; border-radius: 0.4rem; font-size: 0.7rem; font-weight: 600; font-family: sans-serif; background: rgba(255, 255, 255, 1); color: var(--c-text-muted); border: 1px solid var(--c-border-card); cursor: pointer; opacity: 1; transition: opacity 0.15s, background 0.15s, color 0.15s; user-select: none; }
-        [data-theme="light"] .copy-block-btn { background: rgba(0, 0, 0, 1); }
-        .copy-block:hover .copy-block-btn { opacity: 1; }
-        .copy-block-btn:hover { background: rgba(168, 85, 247, 1); color: #a855f7; border-color: rgba(168, 85, 247, 0.3); }
-        .copy-block-btn.copied { background: rgba(168, 85, 247, 1); color: #a855f7; border-color: rgba(168, 85, 247, 0.4); opacity: 1; }
+        .copy-block-btn {
+            position: absolute; top: 0.6rem; right: 0.6rem; z-index: 10;
+            display: flex; align-items: center; gap: 0.35rem;
+            padding: 0.25rem 0.6rem; border-radius: 0.4rem;
+            font-size: 0.7rem; font-weight: 600; font-family: sans-serif;
+            background: rgba(255, 255, 255, 0.06);
+            color: var(--c-text-muted);
+            border: 1px solid var(--c-border-card);
+            cursor: pointer; opacity: 1;
+            transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+            user-select: none;
+            backdrop-filter: blur(6px);
+        }
+        [data-theme="light"] .copy-block-btn { background: rgba(0, 0, 0, 0.05); }
+        .copy-block-btn:hover {
+            background: rgba(52, 211, 153, 0.15);
+            color: #34d399;
+            border-color: rgba(52, 211, 153, 0.4);
+        }
+        .copy-block-btn.copied {
+            background: #34d399;
+            color: #0a0f1a;
+            border-color: #34d399;
+            opacity: 1;
+        }
 
         .anchor-link { opacity: 0; transition: opacity 0.15s; color: var(--c-text-faint); text-decoration: none; }
         .anchor-heading:hover .anchor-link { opacity: 1; }

--- a/docs/url-adapter.html
+++ b/docs/url-adapter.html
@@ -368,6 +368,62 @@ builder.filter("userName", "Jane").sort("createdAt", "desc")
                     The adapter reads the aliases from the builder config automatically, so you
                     only declare them once.
                 </p>
+
+                <h3 class="text-lg font-bold mb-2 mt-10 t-heading">Different names for URL and backend</h3>
+                <p class="t-muted text-sm mb-4 leading-relaxed">
+                    The URL and the backend don't have to share the same naming. Maybe you want the
+                    URL to speak the user's language (<code class="text-purple-400">?filter[documento]=…</code>)
+                    while your API keeps technical names (<code class="text-purple-400">?filter[code]=…</code>).
+                    Pass <code class="text-purple-400">urlAliases</code> to the adapter independently
+                    of the builder's <code class="text-purple-400">aliases</code>:
+                </p>
+                <div class="copy-block">
+                    <button class="copy-block-btn" onclick="copyBlock(this)"><svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>Copy</button>
+<pre><code class="language-typescript">useQueryBuilder({
+  aliases:    { dni: "code", rol: "type" },         // state → backend
+  adapter: createSearchParamsAdapter({
+    sync: true,
+    urlAliases: { dni: "documento", rol: "type" }, // state → URL bar
+  }),
+})
+
+builder.filter("dni", "12345").filter("rol", "admin")
+// URL bar:  ?filter[documento]=12345&filter[type]=admin   ← user sees this
+// .build(): ?filter[code]=12345&filter[type]=admin        ← API receives this</code></pre>
+                </div>
+                <p class="t-muted mt-4 text-sm leading-relaxed">
+                    Three independent namespaces for the same logical attribute:
+                </p>
+                <table class="compare-table mt-3">
+                    <thead>
+                        <tr><th>Layer</th><th>Name</th><th>Controlled by</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>State (your code)</td><td><code class="text-purple-400">dni</code>, <code class="text-purple-400">rol</code></td><td>how you call <code class="text-purple-400">.filter()</code></td></tr>
+                        <tr><td>URL bar</td><td><code class="text-purple-400">documento</code>, <code class="text-purple-400">type</code></td><td><code class="text-purple-400">adapter.urlAliases</code></td></tr>
+                        <tr><td>Backend</td><td><code class="text-purple-400">code</code>, <code class="text-purple-400">type</code></td><td><code class="text-purple-400">builder.aliases</code></td></tr>
+                    </tbody>
+                </table>
+                <p class="t-muted text-sm mt-4 leading-relaxed">
+                    Omit <code class="text-purple-400">urlAliases</code> to make the URL share the
+                    builder's names (the common case). Pass <code class="text-purple-400">urlAliases: {}</code>
+                    to opt out of any URL translation — the URL then mirrors your state-space names
+                    verbatim, even when <code class="text-purple-400">builder.aliases</code> is set.
+                </p>
+
+                <div class="callout callout-warn mt-6">
+                    <p class="callout-title">Security note</p>
+                    <p class="t-muted text-sm leading-relaxed">
+                        With URL ≠ backend, an attacker who knows the backend name could craft
+                        <code class="text-amber-400">?filter[code]=…</code> directly. Lock it down with
+                        an allowlist on the adapter:
+                    </p>
+<pre class="mt-3"><code class="language-typescript">adapter: createSearchParamsAdapter({
+  sync: true,
+  urlAliases: { dni: "documento", rol: "type" },
+  allowed: { filters: ["documento", "type"] },   // backend-name attempts → dropped
+})</code></pre>
+                </div>
             </div>
 
             <!-- KEYS -->
@@ -552,7 +608,7 @@ serializeSearchParams({
                 </div>
                 <p class="t-muted text-sm mt-4 leading-relaxed">
                     Both accept the same <code class="text-purple-400">keys</code> /
-                    <code class="text-purple-400">aliases</code> /
+                    <code class="text-purple-400">urlAliases</code> /
                     <code class="text-purple-400">allowed</code> /
                     <code class="text-purple-400">excludeKeys</code> options as the adapter, plus an
                     optional pre-compiled <code class="text-purple-400">PolicyGate</code> as the

--- a/docs/url-adapter.html
+++ b/docs/url-adapter.html
@@ -277,7 +277,7 @@ builder.filter("status", "active").sort("created_at", "desc")
                 </p>
                 <ul class="t-muted text-sm space-y-1.5 mt-2 list-disc list-inside leading-relaxed">
                     <li>On mount, the adapter <strong>read</strong> the URL and seeded the builder.</li>
-                    <li><code class="text-purple-400">sync: true</code> makes it <strong>write</strong> back on every change via <code class="text-purple-400">history.replaceState</code>.</li>
+                    <li><code class="text-purple-400">sync: true</code> then <strong>writes once right after mount</strong> to normalise the URL against the final state (defaults, <code class="text-purple-400">urlOmit</code>, a stale link — no mutation required), and on every subsequent change.</li>
                     <li>The URL output mirrors what <code class="text-purple-400">.build()</code> emits, so backend and URL bar agree.</li>
                 </ul>
             </div>
@@ -326,7 +326,21 @@ createSearchParamsAdapter({
 })</code></pre>
                 </div>
 
-                <div class="callout callout-info mt-6">
+                <div class="callout callout-tip mt-6">
+                    <p class="callout-title">Mount-time normalisation</p>
+                    <p class="t-muted text-sm leading-relaxed">
+                        The writer fires once right after the builder is constructed in all three
+                        modes, so the URL bar lands on the final state immediately — no mutation
+                        needed for <code class="text-purple-400">urlOmit</code>, defaults, or stale
+                        links to take effect. For <code class="text-purple-400">sync: "push"</code>
+                        the very first call still uses <code class="text-purple-400">replaceState</code>
+                        (so this mount fire doesn't add a phantom back-button entry). Custom
+                        callbacks also fire on mount — guard with a closure flag if your router
+                        would loop on a redirect.
+                    </p>
+                </div>
+
+                <div class="callout callout-info mt-4">
                     <p class="callout-title">Other apps' query params are safe</p>
                     <p class="t-muted text-sm leading-relaxed">
                         The writer preserves anything it doesn't recognise. So

--- a/llms.txt
+++ b/llms.txt
@@ -150,13 +150,14 @@ object with the shape:
 
 ```ts
 interface QueryBuilderAdapter<Aliases = undefined> {
-  read:  () => Partial<GlobalState<Aliases>>
+  read:  (context?: { aliases?: Aliases }) => Partial<GlobalState<Aliases>>
   write?: (state: GlobalState<Aliases>) => void
 }
 ```
 
-- `read()` runs **exactly once** at builder creation — lazy init, like
-  `useState(() => ...)`. Its return seeds the initial state.
+- `read(context)` runs **exactly once** at builder creation — lazy init, like
+  `useState(() => ...)`. The builder passes its `aliases` through `context`
+  so adapters can stay aligned without you declaring them twice.
 - `write?(state)` is optional. When defined, it runs on every state change
   (registered as an internal subscriber) — use for two-way binding.
 - Precedence: built-in defaults < `adapter.read()` < explicit `BaseConfig`
@@ -178,9 +179,23 @@ const urlAdapter = createSearchParamsAdapter({
   // Optional: explicit allowlist of extra query params to preserve as `params`.
   // Unknown params not in this list are ignored. Default: [] (nothing extra).
   allowedParams: ['locale', 'tenant'],
+  // Optional defense-in-depth denylist. Drops any matching attribute on read
+  // (overrides allowedParams). Use to block URL injection of sensitive keys
+  // like ?filter[is_admin]=true.
+  excludeKeys: ['is_admin', 'password', 'tenant_id'],
   // Optional. Default: () => window.location.search (returns "" in SSR).
   // Evaluated inside read(), so module-scope instantiation is safe.
   source: () => window.location.search,
+  // Optional: enable two-way binding (write).
+  //   true | 'replace' → history.replaceState (no extra history entries)
+  //   'push'           → history.pushState (each mutation adds a back step)
+  //   (search) => void → custom — receives the serialised query string
+  //                       (e.g. router integration, debouncing)
+  sync: true,
+  // Optional: frontend→backend attribute map. Reader applies the reverse map
+  // (URL holds backend names, state holds frontend names); writer applies
+  // forward. If omitted here, picked up from BaseConfig.aliases via context.
+  aliases: { userName: 'name' },
 })
 
 const builder = useQueryBuilder({ adapter: urlAdapter })
@@ -191,7 +206,11 @@ Configurable URL keys: `filter`, `sort`, `include`, `fields`. **`page` and
 them preserved as raw params.
 
 Output `build()` always uses the **default** keys (`filter`, `sort`, etc.).
-Renamed keys only apply when **reading** from the URL.
+Renamed keys only apply when **reading from / writing to** the URL.
+
+The built-in writer **preserves any query params not managed by the adapter**
+(anything not matching `keys` or `allowedParams`) so third-party params like
+`utm_source` are left untouched.
 
 ### Custom adapter — localStorage (two-way)
 
@@ -222,29 +241,15 @@ const localStorageAdapter: QueryBuilderAdapter = {
 const builder = useQueryBuilder({ adapter: localStorageAdapter })
 ```
 
-### Two-way URL binding
+### Lower-level: `parseSearchParams` / `serializeSearchParams`
+
+Both pure (no DOM), exported for ad-hoc use without the adapter wrapper:
 
 ```ts
-import { useQueryBuilder, parseSearchParams } from "@cgarciagarcia/react-query-builder"
-
-useQueryBuilder({
-  adapter: {
-    read:  () => parseSearchParams(window.location.search),
-    write: (state) => {
-      const url = new URL(window.location.href)
-      url.search = builder.build() // or any custom serializer
-      window.history.replaceState(null, "", url)
-    },
-  },
-})
-```
-
-### Lower-level: `parseSearchParams`
-
-Pure (no DOM) parser, exported if you need it without the adapter wrapper:
-
-```ts
-import { parseSearchParams } from "@cgarciagarcia/react-query-builder"
+import {
+  parseSearchParams,
+  serializeSearchParams,
+} from "@cgarciagarcia/react-query-builder"
 
 parseSearchParams("?filt[status]=active&srt=-name", {
   keys: { filter: "filt", sort: "srt" },
@@ -252,6 +257,12 @@ parseSearchParams("?filt[status]=active&srt=-name", {
 })
 // → { filters: [{ attribute: "status", value: ["active"] }],
 //     sorts:   [{ attribute: "name",   direction: "desc"   }] }
+
+serializeSearchParams({
+  filters: [{ attribute: "status", value: ["active"] }],
+  sorts:   [{ attribute: "name",   direction: "desc"   }],
+})
+// → "filter[status]=active&sort=-name"
 ```
 
 ## Integration with TanStack Query

--- a/llms.txt
+++ b/llms.txt
@@ -158,8 +158,14 @@ interface QueryBuilderAdapter<Aliases = undefined> {
 - `read(context)` runs **exactly once** at builder creation — lazy init, like
   `useState(() => ...)`. The builder passes its `aliases` through `context`
   so adapters can stay aligned without you declaring them twice.
-- `write?(state)` is optional. When defined, it runs on every state change
-  (registered as an internal subscriber) — use for two-way binding.
+- `write?(state)` is optional. When defined, the builder fires it once
+  right after construction (to normalise the external source against the
+  final state — `BaseConfig` defaults, `urlOmit`, etc. — without waiting
+  for a mutation), then on every state change.
+  The built-in URL adapter forces `replaceState` on that first call so
+  `sync: "push"` doesn't add a phantom history entry; custom callbacks
+  fire on mount too — guard with a closure flag if your router would
+  loop on a redirect-on-mount.
 - Precedence: built-in defaults < `adapter.read()` < explicit `BaseConfig`
   fields. Passing `filters: [...]` alongside an adapter overrides what
   `read()` returned for that field.

--- a/llms.txt
+++ b/llms.txt
@@ -212,6 +212,10 @@ const urlAdapter = createSearchParamsAdapter({
   // Pass `urlAliases: {}` to opt out of any translation (URL == state).
   // Set explicitly when you want URL ≠ backend, e.g. user-friendly URL.
   urlAliases: { dni: 'documento' },
+  // Writer-only denylist per bucket. Listed names stay in state (so
+  // .build() still emits them to the API) but are skipped on URL write.
+  // Use for backend-required context the user shouldn't see in the URL.
+  urlOmit: { includes: ['organization', 'permissions'] },
 })
 
 const builder = useQueryBuilder({ adapter: urlAdapter })

--- a/llms.txt
+++ b/llms.txt
@@ -206,10 +206,12 @@ const urlAdapter = createSearchParamsAdapter({
   //   (search) => void → custom — receives the serialised query string
   //                       (e.g. router integration, debouncing)
   sync: true,
-  // Optional: frontend→backend attribute map. Reader applies the reverse map
-  // (URL holds backend names, state holds frontend names); writer applies
-  // forward. If omitted here, picked up from BaseConfig.aliases via context.
-  aliases: { userName: 'name' },
+  // Optional `state → URL` attribute map for the URL namespace only.
+  // (BaseConfig.aliases is `state → backend` and drives .build()).
+  // Omit to inherit the builder's aliases (URL == backend, common case).
+  // Pass `urlAliases: {}` to opt out of any translation (URL == state).
+  // Set explicitly when you want URL ≠ backend, e.g. user-friendly URL.
+  urlAliases: { dni: 'documento' },
 })
 
 const builder = useQueryBuilder({ adapter: urlAdapter })

--- a/llms.txt
+++ b/llms.txt
@@ -227,9 +227,10 @@ const urlAdapter = createSearchParamsAdapter({
 const builder = useQueryBuilder({ adapter: urlAdapter })
 ```
 
-Configurable URL keys: `filter`, `sort`, `include`, `fields`. **`page` and
-`limit` are NOT auto-hydrated** — add them to `allowed.params` if you want
-them preserved as raw params.
+Configurable URL keys: `filter`, `sort`, `include`, `fields`.
+Pagination (`page` / `limit`) is **auto-hydrated** when present in the
+URL and emitted by the writer when set on the builder — round-trips out
+of the box, no extra config.
 
 Output `build()` always uses the **default** keys (`filter`, `sort`, etc.).
 Renamed keys only apply when **reading from / writing to** the URL.

--- a/llms.txt
+++ b/llms.txt
@@ -221,7 +221,12 @@ const urlAdapter = createSearchParamsAdapter({
   // Writer-only denylist per bucket. Listed names stay in state (so
   // .build() still emits them to the API) but are skipped on URL write.
   // Use for backend-required context the user shouldn't see in the URL.
-  urlOmit: { includes: ['organization', 'permissions'] },
+  // Wildcard "*" drops every entry in that bucket — handy for `fields`,
+  // which are usually an internal API optimisation.
+  urlOmit: {
+    includes: ['organization', 'permissions'],
+    fields:   ['*'],
+  },
 })
 
 const builder = useQueryBuilder({ adapter: urlAdapter })

--- a/llms.txt
+++ b/llms.txt
@@ -279,6 +279,18 @@ serializeSearchParams({
 // → "filter[status]=active&sort=-name"
 ```
 
+### Known protocol limitations (URL adapter)
+
+Filter values must not contain control symbols of the protocol; they
+silently corrupt on round-trip:
+
+- `,`  → multi-value separator (`filter[tag]=a,b` → `["a", "b"]`).
+- Leading `<`, `>`, `<=`, `>=`, `<>` → operator prefixes (`filter[age]=>=18`
+  → operator `>=`, value `["18"]`).
+
+Other "special-looking" characters (`%`, `&`, `+`, spaces) ARE safe — they
+travel URL-escaped and round-trip intact.
+
 ## Integration with TanStack Query
 
 ```ts

--- a/llms.txt
+++ b/llms.txt
@@ -45,6 +45,7 @@ interface BaseConfig {
   }
   useQuestionMark?: boolean  // prepend "?" to build() output (default: true)
   pagination?: { page: number; limit?: number }
+  adapter?: QueryBuilderAdapter  // see "Adapters" section below
 }
 ```
 
@@ -141,6 +142,117 @@ const builder = useQueryBuilder({
 ```
 
 Conflicts are automatically bidirectional.
+
+## Adapters (hydrating from external sources)
+
+The builder bridges to external state sources via `adapter`. An adapter is any
+object with the shape:
+
+```ts
+interface QueryBuilderAdapter<Aliases = undefined> {
+  read:  () => Partial<GlobalState<Aliases>>
+  write?: (state: GlobalState<Aliases>) => void
+}
+```
+
+- `read()` runs **exactly once** at builder creation — lazy init, like
+  `useState(() => ...)`. Its return seeds the initial state.
+- `write?(state)` is optional. When defined, it runs on every state change
+  (registered as an internal subscriber) — use for two-way binding.
+- Precedence: built-in defaults < `adapter.read()` < explicit `BaseConfig`
+  fields. Passing `filters: [...]` alongside an adapter overrides what
+  `read()` returned for that field.
+
+### Built-in URL adapter
+
+```ts
+import {
+  useQueryBuilder,
+  createSearchParamsAdapter,
+} from "@cgarciagarcia/react-query-builder"
+
+const urlAdapter = createSearchParamsAdapter({
+  // Optional: rename the URL keys the parser looks for.
+  // Omitted keys keep their default ('filter' | 'sort' | 'include' | 'fields').
+  keys: { filter: 'filt', sort: 'srt', include: 'inc', fields: 'fld' },
+  // Optional: explicit allowlist of extra query params to preserve as `params`.
+  // Unknown params not in this list are ignored. Default: [] (nothing extra).
+  allowedParams: ['locale', 'tenant'],
+  // Optional. Default: () => window.location.search (returns "" in SSR).
+  // Evaluated inside read(), so module-scope instantiation is safe.
+  source: () => window.location.search,
+})
+
+const builder = useQueryBuilder({ adapter: urlAdapter })
+```
+
+Configurable URL keys: `filter`, `sort`, `include`, `fields`. **`page` and
+`limit` are NOT auto-hydrated** — add them to `allowedParams` if you want
+them preserved as raw params.
+
+Output `build()` always uses the **default** keys (`filter`, `sort`, etc.).
+Renamed keys only apply when **reading** from the URL.
+
+### Custom adapter — localStorage (two-way)
+
+```ts
+import {
+  useQueryBuilder,
+  type QueryBuilderAdapter,
+} from "@cgarciagarcia/react-query-builder"
+
+const STORAGE_KEY = "user-filters"
+
+const localStorageAdapter: QueryBuilderAdapter = {
+  read: () => {
+    try { return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") }
+    catch { return {} }
+  },
+  write: (state) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      filters:    state.filters,
+      sorts:      state.sorts,
+      fields:     state.fields,
+      includes:   state.includes,
+      pagination: state.pagination,
+    }))
+  },
+}
+
+const builder = useQueryBuilder({ adapter: localStorageAdapter })
+```
+
+### Two-way URL binding
+
+```ts
+import { useQueryBuilder, parseSearchParams } from "@cgarciagarcia/react-query-builder"
+
+useQueryBuilder({
+  adapter: {
+    read:  () => parseSearchParams(window.location.search),
+    write: (state) => {
+      const url = new URL(window.location.href)
+      url.search = builder.build() // or any custom serializer
+      window.history.replaceState(null, "", url)
+    },
+  },
+})
+```
+
+### Lower-level: `parseSearchParams`
+
+Pure (no DOM) parser, exported if you need it without the adapter wrapper:
+
+```ts
+import { parseSearchParams } from "@cgarciagarcia/react-query-builder"
+
+parseSearchParams("?filt[status]=active&srt=-name", {
+  keys: { filter: "filt", sort: "srt" },
+  allowedParams: ["locale"],
+})
+// → { filters: [{ attribute: "status", value: ["active"] }],
+//     sorts:   [{ attribute: "name",   direction: "desc"   }] }
+```
 
 ## Integration with TanStack Query
 

--- a/llms.txt
+++ b/llms.txt
@@ -176,13 +176,27 @@ const urlAdapter = createSearchParamsAdapter({
   // Optional: rename the URL keys the parser looks for.
   // Omitted keys keep their default ('filter' | 'sort' | 'include' | 'fields').
   keys: { filter: 'filt', sort: 'srt', include: 'inc', fields: 'fld' },
-  // Optional: explicit allowlist of extra query params to preserve as `params`.
-  // Unknown params not in this list are ignored. Default: [] (nothing extra).
-  allowedParams: ['locale', 'tenant'],
-  // Optional defense-in-depth denylist. Drops any matching attribute on read
-  // (overrides allowedParams). Use to block URL injection of sensitive keys
-  // like ?filter[is_admin]=true.
-  excludeKeys: ['is_admin', 'password', 'tenant_id'],
+  // Optional bucket-scoped allowlist. Applies on read AND write
+  // (symmetric — URL never carries entries outside the policy). Omit a
+  // bucket → its default: filters/sorts/includes/fields = allow-all,
+  // params = deny-all. When you DO list a bucket, only those names pass.
+  allowed: {
+    filters:  ['status', 'role', 'created_at'],
+    sorts:    ['created_at', 'name'],
+    includes: ['author', 'tags'],
+    fields:   ['id', 'title', 'user.name'],
+    params:   ['locale', 'tenant'],
+  },
+  // Optional bucket-scoped defense-in-depth denylist. Each bucket has its
+  // own deny list, because a name (e.g. 'password') may be dangerous as a
+  // filter but legitimate as a `fields` entry. Wins over `allowed`.
+  excludeKeys: {
+    filters:  ['is_admin', 'tenant_id', 'password'],
+    includes: ['internal_audit_log'],
+    sorts:    ['secret_score'],
+    fields:   ['api_token'],
+    params:   ['debug'],
+  },
   // Optional. Default: () => window.location.search (returns "" in SSR).
   // Evaluated inside read(), so module-scope instantiation is safe.
   source: () => window.location.search,
@@ -202,14 +216,14 @@ const builder = useQueryBuilder({ adapter: urlAdapter })
 ```
 
 Configurable URL keys: `filter`, `sort`, `include`, `fields`. **`page` and
-`limit` are NOT auto-hydrated** — add them to `allowedParams` if you want
+`limit` are NOT auto-hydrated** — add them to `allowed.params` if you want
 them preserved as raw params.
 
 Output `build()` always uses the **default** keys (`filter`, `sort`, etc.).
 Renamed keys only apply when **reading from / writing to** the URL.
 
 The built-in writer **preserves any query params not managed by the adapter**
-(anything not matching `keys` or `allowedParams`) so third-party params like
+(anything not matching `keys` or `allowed.params`) so third-party params like
 `utm_source` are left untouched.
 
 ### Custom adapter — localStorage (two-way)
@@ -253,7 +267,7 @@ import {
 
 parseSearchParams("?filt[status]=active&srt=-name", {
   keys: { filter: "filt", sort: "srt" },
-  allowedParams: ["locale"],
+  allowed: { params: ["locale"] },
 })
 // → { filters: [{ attribute: "status", value: ["active"] }],
 //     sorts:   [{ attribute: "name",   direction: "desc"   }] }

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -61,14 +61,26 @@ const makeWriter = <A extends Record<string, string> | undefined = undefined>(
   policy: PolicyGate,
 ): ((state: GlobalState<A>) => void) => {
   const sync = options.sync;
+  // The Builder fires `write(state)` once on mount (to normalise the URL
+  // bar against the final state) and then on every mutation. The first
+  // call always uses `replaceState`, even when `sync === "push"`, so the
+  // mount-time normalisation doesn't add a phantom back-button entry —
+  // subsequent mutations honour the configured mode.
+  let isFirstCall = true;
   return (state) => {
+    const firstCall = isFirstCall;
+    isFirstCall = false;
+
     const serialized = serializeSearchParams<A>(state, options, policy);
+
     if (typeof sync === "function") {
       sync(serialized);
       return;
     }
+
     const next = mergeManagedSearch(defaultSource(), serialized, options);
-    writeToHistory(next, sync === "push" ? "push" : "replace");
+    const mode = !firstCall && sync === "push" ? "push" : "replace";
+    writeToHistory(next, mode);
   };
 };
 
@@ -131,6 +143,7 @@ export const createSearchParamsAdapter = <
       );
     },
   };
+
 
   if (options?.sync !== undefined) {
     adapter.write = makeWriter<Aliases>(options, policy);

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -14,8 +14,7 @@ const defaultSource = (): string =>
  * any callable that returns a query string (useful for SSR, tests, hash
  * routers, etc.).
  *
- * The adapter is meant to be composed with `useQueryBuilder`'s `initialState`
- * for lazy, one-time hydration:
+ * The adapter is meant to be passed straight to `useQueryBuilder`:
  *
  * ```ts
  * const urlAdapter = createSearchParamsAdapter({
@@ -23,7 +22,7 @@ const defaultSource = (): string =>
  *   allowedParams: ["locale"],
  * });
  *
- * useQueryBuilder({ initialState: () => urlAdapter.read() });
+ * useQueryBuilder({ adapter: urlAdapter });
  * ```
  */
 export const createSearchParamsAdapter = <

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -4,10 +4,7 @@ import {
   type QueryBuilderAdapter,
   type SearchParamsAdapterOptions,
 } from "@/types";
-import {
-  DEFAULT_URL_KEYS,
-  parseSearchParams,
-} from "@/utils/parseSearchParams";
+import { DEFAULT_URL_KEYS, parseSearchParams } from "@/utils/parseSearchParams";
 import { serializeSearchParams } from "@/utils/serializeSearchParams";
 
 const defaultSource = (): string =>
@@ -18,7 +15,7 @@ const isManagedKey = (
   options: SearchParamsAdapterOptions,
 ): boolean => {
   const keys = { ...DEFAULT_URL_KEYS, ...(options.keys ?? {}) };
-  const allowed = options.allowedParams ?? [];
+  const managedParams = options.allowed?.params ?? [];
   return (
     key === keys.filter ||
     key.startsWith(`${keys.filter}[`) ||
@@ -26,7 +23,7 @@ const isManagedKey = (
     key.startsWith(`${keys.fields}[`) ||
     key === keys.sort ||
     key === keys.include ||
-    allowed.includes(key)
+    managedParams.includes(key)
   );
 };
 
@@ -54,9 +51,7 @@ const writeToHistory = (search: string, mode: "replace" | "push"): void => {
   window.history[method](null, "", url);
 };
 
-const makeWriter = <
-  A extends Record<string, string> | undefined = undefined,
->(
+const makeWriter = <A extends Record<string, string> | undefined = undefined>(
   options: SearchParamsAdapterOptions,
 ): ((state: GlobalState<A>) => void) => {
   const sync = options.sync;
@@ -66,11 +61,7 @@ const makeWriter = <
       sync(serialized);
       return;
     }
-    const next = mergeManagedSearch(
-      typeof window === "undefined" ? "" : window.location.search,
-      serialized,
-      options,
-    );
+    const next = mergeManagedSearch(defaultSource(), serialized, options);
     writeToHistory(next, sync === "push" ? "push" : "replace");
   };
 };
@@ -89,7 +80,7 @@ const makeWriter = <
  * ```ts
  * const urlAdapter = createSearchParamsAdapter({
  *   keys: { filter: "filt", sort: "srt" },
- *   allowedParams: ["locale"],
+ *   allowed: { params: ["locale"] },
  *   sync: true, // two-way binding via history.replaceState
  * });
  *
@@ -102,9 +93,7 @@ export const createSearchParamsAdapter = <
   options?: SearchParamsAdapterOptions,
 ): QueryBuilderAdapter<Aliases> => {
   const adapter: QueryBuilderAdapter<Aliases> = {
-    read(
-      context?: AdapterReadContext<Aliases>,
-    ): Partial<GlobalState<Aliases>> {
+    read(context?: AdapterReadContext<Aliases>): Partial<GlobalState<Aliases>> {
       const source = options?.source ?? defaultSource;
       const aliases = options?.aliases ?? context?.aliases;
       return parseSearchParams<Aliases>(source(), { ...options, aliases });

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -9,6 +9,10 @@ import {
   parseSearchParams,
   prettifyBrackets,
 } from "@/utils/parseSearchParams";
+import {
+  compilePolicy,
+  type PolicyGate,
+} from "@/utils/searchParamsPolicy";
 import { serializeSearchParams } from "@/utils/serializeSearchParams";
 
 const defaultSource = (): string =>
@@ -57,10 +61,11 @@ const writeToHistory = (search: string, mode: "replace" | "push"): void => {
 
 const makeWriter = <A extends Record<string, string> | undefined = undefined>(
   options: SearchParamsAdapterOptions,
+  policy: PolicyGate,
 ): ((state: GlobalState<A>) => void) => {
   const sync = options.sync;
   return (state) => {
-    const serialized = serializeSearchParams<A>(state, options);
+    const serialized = serializeSearchParams<A>(state, options, policy);
     if (typeof sync === "function") {
       sync(serialized);
       return;
@@ -96,16 +101,26 @@ export const createSearchParamsAdapter = <
 >(
   options?: SearchParamsAdapterOptions,
 ): QueryBuilderAdapter<Aliases> => {
+  // Compile the allow/deny policy once at adapter creation. `options` is
+  // immutable for the adapter's lifetime, so the resulting gate is reused
+  // on every read AND every write — keeping the hot path (write fires on
+  // each mutation) free of repeated Set construction.
+  const policy = compilePolicy(options);
+
   const adapter: QueryBuilderAdapter<Aliases> = {
     read(context?: AdapterReadContext<Aliases>): Partial<GlobalState<Aliases>> {
       const source = options?.source ?? defaultSource;
       const aliases = options?.aliases ?? context?.aliases;
-      return parseSearchParams<Aliases>(source(), { ...options, aliases });
+      return parseSearchParams<Aliases>(
+        source(),
+        { ...options, aliases },
+        policy,
+      );
     },
   };
 
   if (options?.sync !== undefined) {
-    adapter.write = makeWriter<Aliases>(options);
+    adapter.write = makeWriter<Aliases>(options, policy);
   }
 
   return adapter;

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -1,0 +1,38 @@
+import {
+  type GlobalState,
+  type QueryBuilderAdapter,
+  type SearchParamsAdapterOptions,
+} from "@/types";
+import { parseSearchParams } from "@/utils/parseSearchParams";
+
+const defaultSource = (): string =>
+  typeof window === "undefined" ? "" : window.location.search;
+
+/**
+ * Build a `QueryBuilderAdapter` that hydrates the builder from a query
+ * string. By default it reads `window.location.search`, but `source` can be
+ * any callable that returns a query string (useful for SSR, tests, hash
+ * routers, etc.).
+ *
+ * The adapter is meant to be composed with `useQueryBuilder`'s `initialState`
+ * for lazy, one-time hydration:
+ *
+ * ```ts
+ * const urlAdapter = createSearchParamsAdapter({
+ *   keys: { filter: "filt", sort: "srt" },
+ *   allowedParams: ["locale"],
+ * });
+ *
+ * useQueryBuilder({ initialState: () => urlAdapter.read() });
+ * ```
+ */
+export const createSearchParamsAdapter = <
+  Aliases extends Record<string, string> | undefined = undefined,
+>(
+  options?: SearchParamsAdapterOptions,
+): QueryBuilderAdapter<Aliases> => ({
+  read(): Partial<GlobalState<Aliases>> {
+    const source = options?.source ?? defaultSource;
+    return parseSearchParams<Aliases>(source(), options);
+  },
+});

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -92,6 +92,19 @@ const makeWriter = <A extends Record<string, string> | undefined = undefined>(
  *
  * useQueryBuilder({ adapter: urlAdapter });
  * ```
+ *
+ * To use different names in the URL than what the API expects, set
+ * `urlAliases` here and `BaseConfig.aliases` on the builder independently:
+ *
+ * ```ts
+ * useQueryBuilder({
+ *   aliases: { dni: "code" },          // state → backend (for .build())
+ *   adapter: createSearchParamsAdapter({
+ *     sync: true,
+ *     urlAliases: { dni: "documento" }, // state → URL (for the URL bar)
+ *   }),
+ * });
+ * ```
  */
 export const createSearchParamsAdapter = <
   Aliases extends Record<string, string> | undefined = undefined,
@@ -107,10 +120,13 @@ export const createSearchParamsAdapter = <
   const adapter: QueryBuilderAdapter<Aliases> = {
     read(context?: AdapterReadContext<Aliases>): Partial<GlobalState<Aliases>> {
       const source = options?.source ?? defaultSource;
-      const aliases = options?.aliases ?? context?.aliases;
+      // Explicit `urlAliases` wins. Otherwise the URL namespace inherits
+      // the builder's `aliases` — so by default URL and backend share
+      // the same naming, which is the common case.
+      const urlAliases = options?.urlAliases ?? context?.aliases;
       return parseSearchParams<Aliases>(
         source(),
-        { ...options, aliases },
+        { ...options, urlAliases },
         policy,
       );
     },

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -1,25 +1,96 @@
 import {
+  type AdapterReadContext,
   type GlobalState,
   type QueryBuilderAdapter,
   type SearchParamsAdapterOptions,
 } from "@/types";
-import { parseSearchParams } from "@/utils/parseSearchParams";
+import {
+  DEFAULT_URL_KEYS,
+  parseSearchParams,
+} from "@/utils/parseSearchParams";
+import { serializeSearchParams } from "@/utils/serializeSearchParams";
 
 const defaultSource = (): string =>
   typeof window === "undefined" ? "" : window.location.search;
 
+const isManagedKey = (
+  key: string,
+  options: SearchParamsAdapterOptions,
+): boolean => {
+  const keys = { ...DEFAULT_URL_KEYS, ...(options.keys ?? {}) };
+  const allowed = options.allowedParams ?? [];
+  return (
+    key === keys.filter ||
+    key.startsWith(`${keys.filter}[`) ||
+    key === keys.fields ||
+    key.startsWith(`${keys.fields}[`) ||
+    key === keys.sort ||
+    key === keys.include ||
+    allowed.includes(key)
+  );
+};
+
+const mergeManagedSearch = (
+  currentSearch: string,
+  nextSerialized: string,
+  options: SearchParamsAdapterOptions,
+): string => {
+  const merged = new URLSearchParams(currentSearch);
+  for (const key of [...merged.keys()]) {
+    if (isManagedKey(key, options)) merged.delete(key);
+  }
+  for (const [k, v] of new URLSearchParams(nextSerialized).entries()) {
+    merged.append(k, v);
+  }
+  const raw = merged.toString();
+  return raw ? "?" + decodeURIComponent(raw) : "";
+};
+
+const writeToHistory = (search: string, mode: "replace" | "push"): void => {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  url.search = search;
+  const method = mode === "push" ? "pushState" : "replaceState";
+  window.history[method](null, "", url);
+};
+
+const makeWriter = <
+  A extends Record<string, string> | undefined = undefined,
+>(
+  options: SearchParamsAdapterOptions,
+): ((state: GlobalState<A>) => void) => {
+  const sync = options.sync;
+  return (state) => {
+    const serialized = serializeSearchParams<A>(state, options);
+    if (typeof sync === "function") {
+      sync(serialized);
+      return;
+    }
+    const next = mergeManagedSearch(
+      typeof window === "undefined" ? "" : window.location.search,
+      serialized,
+      options,
+    );
+    writeToHistory(next, sync === "push" ? "push" : "replace");
+  };
+};
+
 /**
- * Build a `QueryBuilderAdapter` that hydrates the builder from a query
- * string. By default it reads `window.location.search`, but `source` can be
- * any callable that returns a query string (useful for SSR, tests, hash
- * routers, etc.).
+ * Build a `QueryBuilderAdapter` that bridges the builder to a query string.
  *
- * The adapter is meant to be passed straight to `useQueryBuilder`:
+ * - `read()` runs once on builder creation; by default it reads
+ *   `window.location.search` (or whatever `source` returns) and parses it
+ *   through `parseSearchParams`.
+ * - `write(state)` is exposed **only when `sync` is set**. It serialises
+ *   the state through `serializeSearchParams` and pushes it back to the URL
+ *   (preserving any params not managed by this adapter), or hands it to a
+ *   custom callback for router integration / debouncing.
  *
  * ```ts
  * const urlAdapter = createSearchParamsAdapter({
  *   keys: { filter: "filt", sort: "srt" },
  *   allowedParams: ["locale"],
+ *   sync: true, // two-way binding via history.replaceState
  * });
  *
  * useQueryBuilder({ adapter: urlAdapter });
@@ -29,9 +100,20 @@ export const createSearchParamsAdapter = <
   Aliases extends Record<string, string> | undefined = undefined,
 >(
   options?: SearchParamsAdapterOptions,
-): QueryBuilderAdapter<Aliases> => ({
-  read(): Partial<GlobalState<Aliases>> {
-    const source = options?.source ?? defaultSource;
-    return parseSearchParams<Aliases>(source(), options);
-  },
-});
+): QueryBuilderAdapter<Aliases> => {
+  const adapter: QueryBuilderAdapter<Aliases> = {
+    read(
+      context?: AdapterReadContext<Aliases>,
+    ): Partial<GlobalState<Aliases>> {
+      const source = options?.source ?? defaultSource;
+      const aliases = options?.aliases ?? context?.aliases;
+      return parseSearchParams<Aliases>(source(), { ...options, aliases });
+    },
+  };
+
+  if (options?.sync !== undefined) {
+    adapter.write = makeWriter<Aliases>(options);
+  }
+
+  return adapter;
+};

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -28,6 +28,8 @@ const isManagedKey = (
     key.startsWith(`${keys.fields}[`) ||
     key === keys.sort ||
     key === keys.include ||
+    key === "page" ||
+    key === "limit" ||
     managedParams.includes(key)
   );
 };
@@ -143,7 +145,6 @@ export const createSearchParamsAdapter = <
       );
     },
   };
-
 
   if (options?.sync !== undefined) {
     adapter.write = makeWriter<Aliases>(options, policy);

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -4,7 +4,11 @@ import {
   type QueryBuilderAdapter,
   type SearchParamsAdapterOptions,
 } from "@/types";
-import { DEFAULT_URL_KEYS, parseSearchParams } from "@/utils/parseSearchParams";
+import {
+  DEFAULT_URL_KEYS,
+  parseSearchParams,
+  prettifyBrackets,
+} from "@/utils/parseSearchParams";
 import { serializeSearchParams } from "@/utils/serializeSearchParams";
 
 const defaultSource = (): string =>
@@ -40,7 +44,7 @@ const mergeManagedSearch = (
     merged.append(k, v);
   }
   const raw = merged.toString();
-  return raw ? "?" + decodeURIComponent(raw) : "";
+  return raw ? "?" + prettifyBrackets(raw) : "";
 };
 
 const writeToHistory = (search: string, mode: "replace" | "push"): void => {

--- a/src/adapters/searchParams.ts
+++ b/src/adapters/searchParams.ts
@@ -9,10 +9,7 @@ import {
   parseSearchParams,
   prettifyBrackets,
 } from "@/utils/parseSearchParams";
-import {
-  compilePolicy,
-  type PolicyGate,
-} from "@/utils/searchParamsPolicy";
+import { compilePolicy, type PolicyGate } from "@/utils/searchParamsPolicy";
 import { serializeSearchParams } from "@/utils/serializeSearchParams";
 
 const defaultSource = (): string =>

--- a/src/classes/Builder.ts
+++ b/src/classes/Builder.ts
@@ -111,6 +111,11 @@ export class Builder<
 
     if (adapter?.write) {
       this.addSubscriber(adapter.write);
+      // Normalise the external source against the final state, so it
+      // reflects defaults and `urlOmit` even before the first mutation.
+      // Adapters that don't want this can no-op their first call (the
+      // built-in URL adapter already does so for "push" and custom-fn sync).
+      adapter.write(this.state);
     }
   }
 

--- a/src/classes/Builder.ts
+++ b/src/classes/Builder.ts
@@ -81,7 +81,8 @@ export class Builder<
 
   constructor(config?: BaseConfig<Aliases>) {
     const { adapter, ...rest } = config ?? {};
-    const seeded: Partial<GlobalState<Aliases>> = adapter?.read() ?? {};
+    const seeded: Partial<GlobalState<Aliases>> =
+      adapter?.read({ aliases: rest.aliases }) ?? {};
 
     this.state = {
       aliases: {} as Aliases,

--- a/src/classes/Builder.ts
+++ b/src/classes/Builder.ts
@@ -62,6 +62,10 @@ export class Builder<
 > implements QueryBuilder<Aliases> {
   private state: GlobalState<Aliases>;
 
+  // Stored so `rehydrate()` can re-run `read()` after mount when the
+  // external source has changed (browser back/forward, etc.).
+  private adapter?: BaseConfig<Aliases>["adapter"];
+
   private subscribers: Record<string, (state: GlobalState<Aliases>) => void> =
     {};
 
@@ -81,6 +85,7 @@ export class Builder<
 
   constructor(config?: BaseConfig<Aliases>) {
     const { adapter, ...rest } = config ?? {};
+    this.adapter = adapter;
     const seeded: Partial<GlobalState<Aliases>> =
       adapter?.read({ aliases: rest.aliases }) ?? {};
 
@@ -430,6 +435,26 @@ export class Builder<
   }
   hasPagination(): boolean {
     return !!this.state.pagination;
+  }
+
+  rehydrate(): QueryBuilder<Aliases> {
+    if (!this.adapter) return this;
+    const seeded: Partial<GlobalState<Aliases>> =
+      this.adapter.read({ aliases: this.state.aliases }) ?? {};
+    this.setState((s) => ({
+      ...s,
+      // Replace the data layer (what the source provides); preserve the
+      // config layer (aliases, delimiters, pruneConflictingFilters,
+      // useQuestionMark). An absent key in `seeded` means "the source
+      // has nothing for this bucket" → reset to the empty default.
+      filters: seeded.filters ?? [],
+      sorts: seeded.sorts ?? [],
+      includes: seeded.includes ?? [],
+      fields: seeded.fields ?? [],
+      params: seeded.params ?? {},
+      pagination: seeded.pagination ?? {},
+    }));
+    return this;
   }
 
   private shouldResetPage(): boolean {

--- a/src/classes/Builder.ts
+++ b/src/classes/Builder.ts
@@ -80,6 +80,9 @@ export class Builder<
   };
 
   constructor(config?: BaseConfig<Aliases>) {
+    const { adapter, ...rest } = config ?? {};
+    const seeded: Partial<GlobalState<Aliases>> = adapter?.read() ?? {};
+
     this.state = {
       aliases: {} as Aliases,
       filters: [],
@@ -89,9 +92,10 @@ export class Builder<
       params: {},
       useQuestionMark: true,
       pagination: {},
-      ...(config ?? {}),
+      ...seeded,
+      ...rest,
       pruneConflictingFilters: reverseConflicts(
-        config?.pruneConflictingFilters ?? {},
+        rest.pruneConflictingFilters ?? {},
       ),
       delimiters: {
         global: ",",
@@ -100,9 +104,13 @@ export class Builder<
         sorts: null,
         includes: null,
         params: null,
-        ...(config?.delimiters ?? {}),
+        ...(rest.delimiters ?? {}),
       },
     };
+
+    if (adapter?.write) {
+      this.addSubscriber(adapter.write);
+    }
   }
 
   private setState(fn: (s: GlobalState<Aliases>) => GlobalState<Aliases>) {
@@ -277,7 +285,9 @@ export class Builder<
     if (this.state.pagination?.page && this.state.pagination.page >= 1) {
       this.setState((s) =>
         pageAction(
-          /* v8 ignore next */ s.pagination?.page !== undefined ? s.pagination.page + 1 : 1,
+          /* v8 ignore next */ s.pagination?.page !== undefined
+            ? s.pagination.page + 1
+            : 1,
           s,
         ),
       );
@@ -295,7 +305,10 @@ export class Builder<
   previousPage(): QueryBuilder<Aliases> {
     if (this.state.pagination?.page && this.state.pagination.page > 1) {
       this.setState((s) =>
-        pageAction(/* v8 ignore next */ s.pagination?.page ? s.pagination.page - 1 : 1, s),
+        pageAction(
+          /* v8 ignore next */ s.pagination?.page ? s.pagination.page - 1 : 1,
+          s,
+        ),
       );
     }
     return this;

--- a/src/hooks/useQueryBuilder.ts
+++ b/src/hooks/useQueryBuilder.ts
@@ -22,17 +22,16 @@ export const useQueryBuilder = <
   config?: BaseConfig<Aliases>,
 ): QueryBuilder<Aliases> => {
   const builder = useRef<Builder<Aliases> | null>(null);
-  if (builder.current === null) {
-    builder.current = new Builder<Aliases>(config);
-  }
+  builder.current ??= new Builder<Aliases>(config);
+  const instance = builder.current;
 
   const [, setReRendersCounter] = useState(0);
 
   useMount(() => {
-    builder.current?.addSubscriber(() => {
+    instance.addSubscriber(() => {
       setReRendersCounter((r) => r + 1);
     });
   });
 
-  return builder.current;
+  return instance;
 };

--- a/src/hooks/useQueryBuilder.ts
+++ b/src/hooks/useQueryBuilder.ts
@@ -3,6 +3,19 @@ import { Builder } from "@/classes/Builder";
 import { useMount } from "@/hooks/useMount";
 import { type BaseConfig, type QueryBuilder } from "src/types";
 
+/**
+ * React hook that returns a stable `QueryBuilder` instance.
+ *
+ * **`config` is read only on the first render** (lazy initialization, same
+ * semantics as `useState(() => init)`). The builder is then mutable through
+ * its own methods (`builder.filter(...)`, etc.), and the instance is reused
+ * across re-renders. Passing a different `config` on subsequent renders
+ * does NOT rebuild the builder — if you need to react to a config change,
+ * either mutate the builder directly or remount the component with a `key`.
+ *
+ * This applies equally to nested config fields like `adapter` — the adapter
+ * passed on the first render is the one wired for the lifetime of the hook.
+ */
 export const useQueryBuilder = <
   Aliases extends Record<string, string> | undefined = undefined,
 >(

--- a/src/hooks/useQueryBuilder.ts
+++ b/src/hooks/useQueryBuilder.ts
@@ -8,12 +8,15 @@ export const useQueryBuilder = <
 >(
   config?: BaseConfig<Aliases>,
 ): QueryBuilder<Aliases> => {
-  const builder = useRef(new Builder<Aliases>(config));
+  const builder = useRef<Builder<Aliases> | null>(null);
+  if (builder.current === null) {
+    builder.current = new Builder<Aliases>(config);
+  }
 
   const [, setReRendersCounter] = useState(0);
 
   useMount(() => {
-    builder.current.addSubscriber(() => {
+    builder.current?.addSubscriber(() => {
       setReRendersCounter((r) => r + 1);
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+export * from "@/adapters/searchParams";
 export * from "@/hooks/useQueryBuilder";
 export * from "@/types";
+export * from "@/utils/parseSearchParams";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export * from "@/adapters/searchParams";
 export * from "@/hooks/useQueryBuilder";
 export * from "@/types";
 export * from "@/utils/parseSearchParams";
+export * from "@/utils/searchParamsPolicy";
 export * from "@/utils/serializeSearchParams";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "@/adapters/searchParams";
 export * from "@/hooks/useQueryBuilder";
 export * from "@/types";
 export * from "@/utils/parseSearchParams";
+export * from "@/utils/serializeSearchParams";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -177,22 +177,71 @@ export interface SearchParamsAdapterOptions {
    */
   aliases?: Record<string, string>;
   /**
-   * Explicit allowlist of query params that are NOT `filter`/`sort`/`include`/
-   * `fields` and should be preserved as `params` in the builder state. Any
-   * other unknown param is ignored.
-   */
-  allowedParams?: string[];
-  /**
-   * Defense-in-depth denylist applied to filter / sort / include / field
-   * attribute names AND to params (overrides `allowedParams`). If a URL entry
-   * matches any name here it is silently dropped on read. Use it to block
-   * sensitive backend attributes from being injected via crafted URLs (for
-   * example `is_admin`, `password`, `tenant_id`, `internal_audit_log`).
+   * Bucket-scoped allowlist. **When a bucket is defined**, only entries
+   * matching the list pass through (both on read AND on write — for
+   * round-trip safety). **When omitted**, the bucket's default behavior
+   * applies:
    *
-   * Matching is on the raw URL name (the backend name) before any reverse
-   * alias is applied, since the threat is what reaches the wire.
+   * - `filters` / `sorts` / `includes` / `fields` → default allow-all
+   *   (the whole point of the feature is URL-driven filtering, so being
+   *   strict by default would require enumerating every legal attribute).
+   * - `params` → default deny-all (params are arbitrary app-specific data;
+   *   if you do not declare it, it does not enter).
+   *
+   * ```ts
+   * allowed: {
+   *   filters:  ["status", "role", "created_at"],
+   *   sorts:    ["created_at", "name"],
+   *   includes: ["author", "tags"],
+   *   fields:   ["id", "title", "user.name"],
+   *   params:   ["locale", "tenant"],
+   * }
+   * ```
+   *
+   * Combine with `excludeKeys` (denylist) for layered defense: `allowed`
+   * narrows the input set, `excludeKeys` removes specific entries from
+   * what remains.
    */
-  excludeKeys?: string[];
+  allowed?: {
+    filters?: string[];
+    sorts?: string[];
+    includes?: string[];
+    fields?: string[];
+    params?: string[];
+  };
+  /**
+   * Defense-in-depth denylist, **scoped per bucket**. Each list drops the
+   * matching names from the corresponding bucket on read AND on write;
+   * `params` wins over `allowed.params` (deny over allow). Matching is on
+   * the raw URL name (backend) before any reverse alias is applied, since
+   * the threat is what reaches the wire.
+   *
+   * Per-bucket scoping is intentional: a name like `password` is dangerous
+   * as a filter but legitimate as a `fields` entry (selecting the column).
+   * Saying "deny `password` everywhere" would silently break legitimate
+   * use cases.
+   *
+   * For `fields`, both the short prop name (`password`) and the
+   * fully-qualified `entity.prop` form (`user.password`) match — pick the
+   * precision you need.
+   *
+   * ```ts
+   * excludeKeys: {
+   *   filters:  ["is_admin", "tenant_id"],
+   *   includes: ["internal_audit_log"],
+   *   sorts:    ["secret_score"],
+   *   fields:   ["password", "api_token"],
+   *   params:   ["debug"],
+   * }
+   * ```
+   */
+  excludeKeys?: {
+    filters?: string[];
+    sorts?: string[];
+    includes?: string[];
+    fields?: string[];
+    params?: string[];
+  };
   /**
    * Lazy provider of the query string to parse. Default:
    * `() => window.location.search`. Evaluated when `read()` is called, not
@@ -202,7 +251,8 @@ export interface SearchParamsAdapterOptions {
   /**
    * Enable two-way binding. When set, the adapter exposes a `write(state)`
    * function that the builder invokes on every mutation, serialising the
-   * state back to the URL using the same `keys` and `allowedParams`.
+   * state back to the URL using the same `keys`, `allowed`, and
+   * `excludeKeys` policy as the reader.
    *
    * - `true` (or `"replace"`) — `window.history.replaceState` (no extra
    *   history entry per change). Best for filter/sort UI.
@@ -216,7 +266,7 @@ export interface SearchParamsAdapterOptions {
    *
    * The built-in writer preserves any query params not managed by this
    * adapter (i.e. not matching the configured keys and not in
-   * `allowedParams`), so other consumers of the URL (analytics, locale
+   * `allowed.params`), so other consumers of the URL (analytics, locale
    * switchers, etc.) are left untouched.
    */
   sync?: true | "replace" | "push" | ((search: string) => void);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -159,6 +159,23 @@ export interface QueryBuilder<
  */
 export type ConfigurableURLKey = "filter" | "sort" | "include" | "fields";
 
+/**
+ * Options for the built-in URL adapter / parser / serializer.
+ *
+ * ## Known protocol limitations
+ *
+ * Filter values **must not** contain any of these characters; the URL
+ * protocol uses them as control symbols and a round-trip through the
+ * adapter would silently corrupt the value:
+ *
+ * - `,` — the multi-value separator (`filter[tag]=a,b` → `["a", "b"]`).
+ * - `<`, `>`, `<=`, `>=`, `<>` as the **leading** characters of a value —
+ *   they are parsed as operator prefixes (`filter[age]=>=18` → operator
+ *   `>=`, value `["18"]`).
+ *
+ * Values containing `%`, `&`, `+` and spaces ARE safe — they go through the
+ * URL escaped and survive the round-trip intact.
+ */
 export interface SearchParamsAdapterOptions {
   /**
    * Remap the URL keys the parser looks for. Any omitted key falls back to

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,6 +152,56 @@ export interface QueryBuilder<
   getLimit: () => number | undefined;
 }
 
+/**
+ * URL keys recognized by the built-in `parseSearchParams` and
+ * `createSearchParamsAdapter`. Consumers can remap any of these to a custom
+ * key (e.g. `filter` -> `filt`) while reading from the URL.
+ */
+export type ConfigurableURLKey = "filter" | "sort" | "include" | "fields";
+
+export interface SearchParamsAdapterOptions {
+  /**
+   * Remap the URL keys the parser looks for. Any omitted key falls back to
+   * its default (`filter`, `sort`, `include`, `fields`).
+   */
+  keys?: Partial<Record<ConfigurableURLKey, string>>;
+  /**
+   * Explicit allowlist of query params that are NOT `filter`/`sort`/`include`/
+   * `fields` and should be preserved as `params` in the builder state. Any
+   * other unknown param is ignored.
+   */
+  allowedParams?: string[];
+  /**
+   * Lazy provider of the query string to parse. Default:
+   * `() => window.location.search`. Evaluated when `read()` is called, not
+   * at adapter-creation time, so it is safe to instantiate at module scope.
+   */
+  source?: () => string;
+}
+
+/**
+ * Strategy interface for any data source that can seed (and optionally
+ * persist) the builder state. The built-in `createSearchParamsAdapter` reads
+ * from `window.location.search`; custom adapters (hash router, react-router,
+ * in-memory, localStorage, etc.) implement the same shape.
+ */
+export interface QueryBuilderAdapter<
+  Aliases extends Record<string, string> | undefined = undefined,
+> {
+  /**
+   * Called exactly once when the builder is created. Returns the partial
+   * state to seed the builder with.
+   */
+  read: () => Partial<GlobalState<Aliases>>;
+  /**
+   * Optional. When defined, the builder invokes this on every state change
+   * (it is wired as an internal subscriber). Use it to keep an external
+   * source in sync — for example, `history.replaceState` for two-way URL
+   * binding, or a `localStorage` write.
+   */
+  write?: (state: GlobalState<Aliases>) => void;
+}
+
 export interface BaseConfig<
   AliasType extends Record<string, string> | undefined = undefined,
 > {
@@ -160,6 +210,22 @@ export interface BaseConfig<
   sorts?: Sort<AliasType>[];
   filters?: Filter<AliasType>[];
   fields?: Field[];
+  /**
+   * Bridge to an external source of state — typically a URL parser, but
+   * anything implementing `QueryBuilderAdapter` works (localStorage, hash
+   * router, in-memory store, etc.).
+   *
+   * - `adapter.read()` runs exactly once when the builder is created. Its
+   *   return value seeds the initial state, behaving like the lazy form of
+   *   `useState(() => ...)`.
+   * - `adapter.write(state)` is optional. When defined, it is invoked on
+   *   every state change so the external source can be kept in sync (e.g.
+   *   `history.replaceState` for two-way URL binding).
+   *
+   * Precedence on seed: built-in defaults < `adapter.read()` < the rest of
+   * `BaseConfig` (anything you set explicitly here always wins).
+   */
+  adapter?: QueryBuilderAdapter<AliasType>;
   /**
    * Create a map of filters that don't work together
    */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -205,6 +205,19 @@ export interface SearchParamsAdapterOptions {
    * - `params` → default deny-all (params are arbitrary app-specific data;
    *   if you do not declare it, it does not enter).
    *
+   * For `filters` and `sorts`, when `aliases` are present the policy is
+   * **alias-aware**: an entry matches if **either** the URL-side name
+   * (backend / wire) OR its aliased counterpart (frontend / state) is in
+   * the list. You can write your allowlist in whichever vocabulary you
+   * think in:
+   *
+   * ```ts
+   * aliases: { userName: "name" },
+   * allowed: { filters: ["userName"] }   // works
+   * // — or —
+   * allowed: { filters: ["name"] }       // also works
+   * ```
+   *
    * ```ts
    * allowed: {
    *   filters:  ["status", "role", "created_at"],
@@ -229,9 +242,14 @@ export interface SearchParamsAdapterOptions {
   /**
    * Defense-in-depth denylist, **scoped per bucket**. Each list drops the
    * matching names from the corresponding bucket on read AND on write;
-   * `params` wins over `allowed.params` (deny over allow). Matching is on
-   * the raw URL name (backend) before any reverse alias is applied, since
-   * the threat is what reaches the wire.
+   * `params` wins over `allowed.params` (deny over allow).
+   *
+   * For `filters` and `sorts`, the check is **alias-aware**: an entry is
+   * dropped if **either** the URL name OR its aliased counterpart is in
+   * the list. This closes the bypass where an attacker uses the frontend
+   * alias key in the URL (`?filter[adminFlag]=true`) to defeat a denylist
+   * declared with the backend name (`excludeKeys.filters: ["is_admin"]`)
+   * — both names are checked, so listing either form blocks both.
    *
    * Per-bucket scoping is intentional: a name like `password` is dangerous
    * as a filter but legitimate as a `fields` entry (selecting the column).

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -382,10 +382,25 @@ export interface QueryBuilderAdapter<
     context?: AdapterReadContext<Aliases>,
   ) => Partial<GlobalState<Aliases>>;
   /**
-   * Optional. When defined, the builder invokes this on every state change
-   * (it is wired as an internal subscriber). Use it to keep an external
-   * source in sync — for example, `history.replaceState` for two-way URL
-   * binding, or a `localStorage` write.
+   * Optional. When defined, the builder invokes this:
+   *
+   * 1. **Once on mount**, right after `read()` has seeded and any
+   *    `BaseConfig` overrides have been merged in. This "normalises" the
+   *    external source (typically the URL bar) so it matches the builder's
+   *    final state — useful when `BaseConfig.includes` defaults or
+   *    `urlOmit` make the rendered state diverge from a stale URL the
+   *    user landed on.
+   * 2. **On every subsequent state change** — it's wired as an internal
+   *    subscriber after the initial mount call.
+   *
+   * Custom adapters can guard against the mount call with a closure flag
+   * if they don't want it (e.g. an adapter wrapping a router that would
+   * loop on a redirect-on-mount). The built-in URL adapter already does
+   * this: it forces `replaceState` on the first call regardless of the
+   * configured `sync` mode (so `"push"` doesn't add a phantom history
+   * entry), and skips the mount call entirely when `sync` is a custom
+   * function (so the consumer's callback doesn't fire before any user
+   * action).
    */
   write?: (state: GlobalState<Aliases>) => void;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,6 +150,31 @@ export interface QueryBuilder<
   previousPage: () => QueryBuilder<AliasType>;
   getCurrentPage: () => number | undefined;
   getLimit: () => number | undefined;
+  /**
+   * Re-run the adapter's `read()` and replace the data layer of the
+   * builder state (filters, sorts, includes, fields, params, pagination)
+   * with what it returns. Config-layer fields (aliases, delimiters,
+   * pruneConflictingFilters, useQuestionMark) are preserved.
+   *
+   * Use it to sync the builder with an external source that changed
+   * after mount — most commonly the URL on browser back/forward:
+   *
+   * ```ts
+   * window.addEventListener("popstate", () => builder.rehydrate());
+   * ```
+   *
+   * Triggers subscribers (so the component re-renders) and the adapter
+   * `write` (typically idempotent, e.g. `replaceState` to the same URL).
+   * For non-idempotent writes (websocket, fetch), debounce in your write.
+   *
+   * **Semantics**: full replace of the data layer. If the adapter returns
+   * no `filters`, state filters become `[]`. Suitable for sources of
+   * truth like the URL — if you need merge semantics (e.g. localStorage
+   * that only stores filters), call individual builder methods instead.
+   *
+   * No-op when no `adapter` was configured.
+   */
+  rehydrate: () => QueryBuilder<AliasType>;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,6 +160,18 @@ export interface QueryBuilder<
 export type ConfigurableURLKey = "filter" | "sort" | "include" | "fields";
 
 /**
+ * Entry accepted by `urlOmit` bucket lists. Either a plain attribute name
+ * or the wildcard `"*"`, which omits every entry in that bucket.
+ *
+ * The `(string & {})` half is a TypeScript trick that keeps the `"*"`
+ * literal visible in IDE autocomplete while still allowing any string
+ * value — without it, TS collapses the union to plain `string` and the
+ * wildcard suggestion never surfaces.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type UrlOmitEntry = "*" | (string & {});
+
+/**
  * Options for the built-in URL adapter / parser / serializer.
  *
  * ## Known protocol limitations
@@ -312,16 +324,21 @@ export interface SearchParamsAdapterOptions {
    * // URL bar   → ?…                                   (clean for the user)
    * ```
    *
+   * Each list accepts plain attribute names AND the wildcard `"*"`,
+   * which drops every entry in that bucket. Common case: hide all
+   * `fields` from the URL because they're an internal API optimisation
+   * the user doesn't care about (`urlOmit: { fields: ["*"] }`).
+   *
    * The reader is **not** affected — if a malicious URL contains one of
    * these names, it still goes through the policy. Add the same names to
    * `excludeKeys` if you also want to refuse them on hydration.
    */
   urlOmit?: {
-    filters?: string[];
-    sorts?: string[];
-    includes?: string[];
-    fields?: string[];
-    params?: string[];
+    filters?: UrlOmitEntry[];
+    sorts?: UrlOmitEntry[];
+    includes?: UrlOmitEntry[];
+    fields?: UrlOmitEntry[];
+    params?: UrlOmitEntry[];
   };
   /**
    * Lazy provider of the query string to parse. Default:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -166,17 +166,71 @@ export interface SearchParamsAdapterOptions {
    */
   keys?: Partial<Record<ConfigurableURLKey, string>>;
   /**
+   * Frontend → backend attribute mapping. When set, the reader applies the
+   * REVERSE map (URL contains backend names → state holds frontend names),
+   * and the writer applies the forward map (state holds frontend names → URL
+   * contains backend names). Round-trip-safe with `.build()` since the
+   * builder's `.build()` already produces backend names.
+   *
+   * If you do not pass this here, `createSearchParamsAdapter` picks it up
+   * from the builder's `BaseConfig.aliases` at `read()` time.
+   */
+  aliases?: Record<string, string>;
+  /**
    * Explicit allowlist of query params that are NOT `filter`/`sort`/`include`/
    * `fields` and should be preserved as `params` in the builder state. Any
    * other unknown param is ignored.
    */
   allowedParams?: string[];
   /**
+   * Defense-in-depth denylist applied to filter / sort / include / field
+   * attribute names AND to params (overrides `allowedParams`). If a URL entry
+   * matches any name here it is silently dropped on read. Use it to block
+   * sensitive backend attributes from being injected via crafted URLs (for
+   * example `is_admin`, `password`, `tenant_id`, `internal_audit_log`).
+   *
+   * Matching is on the raw URL name (the backend name) before any reverse
+   * alias is applied, since the threat is what reaches the wire.
+   */
+  excludeKeys?: string[];
+  /**
    * Lazy provider of the query string to parse. Default:
    * `() => window.location.search`. Evaluated when `read()` is called, not
    * at adapter-creation time, so it is safe to instantiate at module scope.
    */
   source?: () => string;
+  /**
+   * Enable two-way binding. When set, the adapter exposes a `write(state)`
+   * function that the builder invokes on every mutation, serialising the
+   * state back to the URL using the same `keys` and `allowedParams`.
+   *
+   * - `true` (or `"replace"`) — `window.history.replaceState` (no extra
+   *   history entry per change). Best for filter/sort UI.
+   * - `"push"` — `window.history.pushState` (every change is a back-button
+   *   step). Use for major navigation steps.
+   * - `(search) => void` — full custom. Receives the serialised query string
+   *   (no leading `?`). Use for router integrations (Next.js, React Router)
+   *   or to add debouncing.
+   *
+   * Omit (or leave `undefined`) to keep the adapter read-only.
+   *
+   * The built-in writer preserves any query params not managed by this
+   * adapter (i.e. not matching the configured keys and not in
+   * `allowedParams`), so other consumers of the URL (analytics, locale
+   * switchers, etc.) are left untouched.
+   */
+  sync?: true | "replace" | "push" | ((search: string) => void);
+}
+
+/**
+ * Subset of the builder config passed to `QueryBuilderAdapter.read()` so
+ * adapters can react to user-level options (e.g., aliases) without the
+ * consumer having to declare them twice.
+ */
+export interface AdapterReadContext<
+  Aliases extends Record<string, string> | undefined = undefined,
+> {
+  aliases?: Aliases;
 }
 
 /**
@@ -189,10 +243,13 @@ export interface QueryBuilderAdapter<
   Aliases extends Record<string, string> | undefined = undefined,
 > {
   /**
-   * Called exactly once when the builder is created. Returns the partial
-   * state to seed the builder with.
+   * Called exactly once when the builder is created. The `context` argument
+   * exposes builder-level config (currently `aliases`) so adapters can stay
+   * aligned with the consumer's settings without duplicating them.
    */
-  read: () => Partial<GlobalState<Aliases>>;
+  read: (
+    context?: AdapterReadContext<Aliases>,
+  ) => Partial<GlobalState<Aliases>>;
   /**
    * Optional. When defined, the builder invokes this on every state change
    * (it is wired as an internal subscriber). Use it to keep an external

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -290,6 +290,40 @@ export interface SearchParamsAdapterOptions {
     params?: string[];
   };
   /**
+   * Writer-only denylist: keep these entries in the builder state (so
+   * `.build()` still emits them to the API) but **omit them from the URL
+   * bar**. Per-bucket, alias-aware (matches both the state name and the
+   * URL/wire name, so you can write your rule in whichever vocabulary).
+   *
+   * Use it when your backend needs context that the user doesn't care
+   * about — typical case: relations or fields the API always requires
+   * (`include=organization,permissions`) that would just clutter the
+   * shareable link.
+   *
+   * ```ts
+   * useQueryBuilder({
+   *   includes: ["organization", "permissions"], // always sent to the API
+   *   adapter: createSearchParamsAdapter({
+   *     sync: true,
+   *     urlOmit: { includes: ["organization", "permissions"] },
+   *   }),
+   * });
+   * // .build() → ?include=organization,permissions&…   (backend gets them)
+   * // URL bar   → ?…                                   (clean for the user)
+   * ```
+   *
+   * The reader is **not** affected — if a malicious URL contains one of
+   * these names, it still goes through the policy. Add the same names to
+   * `excludeKeys` if you also want to refuse them on hydration.
+   */
+  urlOmit?: {
+    filters?: string[];
+    sorts?: string[];
+    includes?: string[];
+    fields?: string[];
+    params?: string[];
+  };
+  /**
    * Lazy provider of the query string to parse. Default:
    * `() => window.location.search`. Evaluated when `read()` is called, not
    * at adapter-creation time, so it is safe to instantiate at module scope.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -183,16 +183,28 @@ export interface SearchParamsAdapterOptions {
    */
   keys?: Partial<Record<ConfigurableURLKey, string>>;
   /**
-   * Frontend → backend attribute mapping. When set, the reader applies the
-   * REVERSE map (URL contains backend names → state holds frontend names),
-   * and the writer applies the forward map (state holds frontend names → URL
-   * contains backend names). Round-trip-safe with `.build()` since the
-   * builder's `.build()` already produces backend names.
+   * `state → URL` attribute mapping for the URL namespace **only**. The
+   * key is the name you use in your code (`builder.filter('dni', …)`),
+   * the value is what shows up in the URL bar.
    *
-   * If you do not pass this here, `createSearchParamsAdapter` picks it up
-   * from the builder's `BaseConfig.aliases` at `read()` time.
+   * This is intentionally **separate from `BaseConfig.aliases`** (which
+   * maps `state → backend` and drives `.build()`). The split lets the URL
+   * speak the user's language while the backend keeps its own technical
+   * names — see "Different names for URL and backend" in the URL Adapter
+   * docs.
+   *
+   * Resolution at runtime:
+   * - If `urlAliases` is set here → use it verbatim.
+   * - If omitted → fall back to the builder's `aliases` (passed in via
+   *   `read({ aliases })`), so URL and backend share the same naming by
+   *   default (the common case).
+   * - Pass `urlAliases: {}` to explicitly opt out of any translation —
+   *   the URL then mirrors the state-space names.
+   *
+   * The reader builds the reverse map internally, so you only declare the
+   * `state → URL` direction once.
    */
-  aliases?: Record<string, string>;
+  urlAliases?: Record<string, string>;
   /**
    * Bucket-scoped allowlist. **When a bucket is defined**, only entries
    * matching the list pass through (both on read AND on write — for

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -1,0 +1,123 @@
+import {
+  type ConfigurableURLKey,
+  type Field,
+  type Filter,
+  type GlobalState,
+  type Include,
+  type OperatorType,
+  type SearchParamsAdapterOptions,
+  type Sort,
+} from "@/types";
+
+const DEFAULT_KEYS: Record<ConfigurableURLKey, string> = {
+  filter: "filter",
+  sort: "sort",
+  include: "include",
+  fields: "fields",
+};
+
+const OPERATOR_PREFIXES: OperatorType[] = ["<>", "<=", ">=", "<", ">"];
+
+const stripLeadingQuestion = (search: string): string =>
+  search.startsWith("?") ? search.slice(1) : search;
+
+const splitCsv = (raw: string): string[] => (raw === "" ? [] : raw.split(","));
+
+const extractOperator = (
+  raw: string,
+): { operator?: OperatorType; rest: string } => {
+  for (const op of OPERATOR_PREFIXES) {
+    if (raw.startsWith(op)) {
+      return { operator: op as OperatorType, rest: raw.slice(op.length) };
+    }
+  }
+  return { rest: raw };
+};
+
+const bracketedKey = (paramKey: string, prefix: string): string | null => {
+  if (!paramKey.startsWith(`${prefix}[`) || !paramKey.endsWith("]")) {
+    return null;
+  }
+  return paramKey.slice(prefix.length + 1, -1);
+};
+
+export const parseSearchParams = <
+  Aliases extends Record<string, string> | undefined = undefined,
+>(
+  search: string,
+  options?: SearchParamsAdapterOptions,
+): Partial<GlobalState<Aliases>> => {
+  const trimmed = stripLeadingQuestion(search ?? "").trim();
+  if (trimmed === "") return {};
+
+  const keys = { ...DEFAULT_KEYS, ...(options?.keys ?? {}) };
+  const allowed = new Set(options?.allowedParams ?? []);
+  const params = new URLSearchParams(trimmed);
+
+  const filters: Filter<Aliases>[] = [];
+  const fields: Field[] = [];
+  const sorts: Sort<Aliases>[] = [];
+  const includes: Include[] = [];
+  const collectedParams: Record<string, (string | number)[]> = {};
+
+  for (const [key, rawValue] of params.entries()) {
+    const filterAttr = bracketedKey(key, keys.filter);
+    if (filterAttr !== null) {
+      const { operator, rest } = extractOperator(rawValue);
+      filters.push({
+        attribute: filterAttr as Filter<Aliases>["attribute"],
+        value: splitCsv(rest),
+        ...(operator ? { operator } : {}),
+      });
+      continue;
+    }
+
+    const fieldEntity = bracketedKey(key, keys.fields);
+    if (fieldEntity !== null) {
+      for (const prop of splitCsv(rawValue)) {
+        fields.push(`${fieldEntity}.${prop}`);
+      }
+      continue;
+    }
+
+    if (key === keys.fields) {
+      for (const f of splitCsv(rawValue)) {
+        fields.push(f);
+      }
+      continue;
+    }
+
+    if (key === keys.sort) {
+      for (const item of splitCsv(rawValue)) {
+        const desc = item.startsWith("-");
+        sorts.push({
+          attribute: (desc
+            ? item.slice(1)
+            : item) as Sort<Aliases>["attribute"],
+          direction: desc ? "desc" : "asc",
+        });
+      }
+      continue;
+    }
+
+    if (key === keys.include) {
+      for (const inc of splitCsv(rawValue)) {
+        includes.push(inc);
+      }
+      continue;
+    }
+
+    if (allowed.has(key)) {
+      collectedParams[key] = splitCsv(rawValue);
+    }
+  }
+
+  const result: Partial<GlobalState<Aliases>> = {};
+  if (filters.length > 0) result.filters = filters;
+  if (fields.length > 0) result.fields = fields;
+  if (sorts.length > 0) result.sorts = sorts;
+  if (includes.length > 0) result.includes = includes;
+  if (Object.keys(collectedParams).length > 0) result.params = collectedParams;
+
+  return result;
+};

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -11,6 +11,21 @@ import {
 } from "@/types";
 import { compilePolicy, type PolicyGate } from "@/utils/searchParamsPolicy";
 
+/**
+ * Default mapping between the four configurable URL keys and the strings
+ * the library uses when no `keys` override is passed. Exported as part of
+ * the public API so consumers writing custom adapters or composing the
+ * pure functions can reference it directly — e.g. to layer overrides on
+ * top:
+ *
+ * ```ts
+ * import { DEFAULT_URL_KEYS } from "@cgarciagarcia/react-query-builder";
+ *
+ * const myKeys = { ...DEFAULT_URL_KEYS, filter: "filt" };
+ * ```
+ *
+ * Changes to these values are a semver-major bump.
+ */
 export const DEFAULT_URL_KEYS: Record<ConfigurableURLKey, string> = {
   filter: "filter",
   sort: "sort",

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -10,7 +10,7 @@ import {
   type Sort,
 } from "@/types";
 
-const DEFAULT_KEYS: Record<ConfigurableURLKey, string> = {
+export const DEFAULT_URL_KEYS: Record<ConfigurableURLKey, string> = {
   filter: "filter",
   sort: "sort",
   include: "include",
@@ -46,6 +46,16 @@ const bracketedKey = (paramKey: string, prefix: string): string | null => {
   return paramKey.slice(prefix.length + 1, -1);
 };
 
+const buildReverseAliases = (
+  aliases: Record<string, string> | undefined,
+): Map<string, string> => {
+  const reverse = new Map<string, string>();
+  for (const [frontend, backend] of Object.entries(aliases ?? {})) {
+    if (!reverse.has(backend)) reverse.set(backend, frontend);
+  }
+  return reverse;
+};
+
 export const parseSearchParams = <
   Aliases extends Record<string, string> | undefined = undefined,
 >(
@@ -55,8 +65,11 @@ export const parseSearchParams = <
   const trimmed = stripLeadingQuestion(search).trim();
   if (trimmed === "") return {};
 
-  const keys = { ...DEFAULT_KEYS, ...(options?.keys ?? {}) };
+  const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
   const allowed = new Set(options?.allowedParams ?? []);
+  const excluded = new Set(options?.excludeKeys ?? []);
+  const reverseAliases = buildReverseAliases(options?.aliases);
+  const aliasOf = (name: string): string => reverseAliases.get(name) ?? name;
   const params = new URLSearchParams(trimmed);
 
   const filters: Filter<Aliases>[] = [];
@@ -68,9 +81,10 @@ export const parseSearchParams = <
   for (const [key, rawValue] of params.entries()) {
     const filterAttr = bracketedKey(key, keys.filter);
     if (filterAttr !== null) {
+      if (excluded.has(filterAttr)) continue;
       const { operator, rest } = extractOperator(rawValue);
       filters.push({
-        attribute: filterAttr as Filter<Aliases>["attribute"],
+        attribute: aliasOf(filterAttr) as Filter<Aliases>["attribute"],
         value: splitCsv(rest),
         ...(operator ? { operator } : {}),
       });
@@ -80,6 +94,9 @@ export const parseSearchParams = <
     const fieldEntity = bracketedKey(key, keys.fields);
     if (fieldEntity !== null) {
       for (const prop of splitCsv(rawValue)) {
+        if (excluded.has(prop) || excluded.has(`${fieldEntity}.${prop}`)) {
+          continue;
+        }
         fields.push(`${fieldEntity}.${prop}`);
       }
       continue;
@@ -87,6 +104,7 @@ export const parseSearchParams = <
 
     if (key === keys.fields) {
       for (const f of splitCsv(rawValue)) {
+        if (excluded.has(f)) continue;
         fields.push(f);
       }
       continue;
@@ -95,10 +113,10 @@ export const parseSearchParams = <
     if (key === keys.sort) {
       for (const item of splitCsv(rawValue)) {
         const desc = item.startsWith("-");
+        const attr = desc ? item.slice(1) : item;
+        if (excluded.has(attr)) continue;
         sorts.push({
-          attribute: (desc
-            ? item.slice(1)
-            : item) as Sort<Aliases>["attribute"],
+          attribute: aliasOf(attr) as Sort<Aliases>["attribute"],
           direction: desc ? "desc" : "asc",
         });
       }
@@ -107,12 +125,13 @@ export const parseSearchParams = <
 
     if (key === keys.include) {
       for (const inc of splitCsv(rawValue)) {
+        if (excluded.has(inc)) continue;
         includes.push(inc);
       }
       continue;
     }
 
-    if (allowed.has(key)) {
+    if (allowed.has(key) && !excluded.has(key)) {
       collectedParams[key] = splitCsv(rawValue);
     }
   }

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -18,6 +18,37 @@ export const DEFAULT_URL_KEYS: Record<ConfigurableURLKey, string> = {
   fields: "fields",
 };
 
+/**
+ * Selectively decodes the percent-escapes that `URLSearchParams.toString()`
+ * emits for characters that are part of THIS library's URL protocol, so the
+ * final string is human-readable: `filter[name]` instead of
+ * `filter%5Bname%5D`, `filter[age]=>=18` instead of `filter[age]=%3E%3D18`,
+ * etc.
+ *
+ * Crucially, it does NOT touch escapes for characters that, if decoded,
+ * would corrupt round-tripping through `URLSearchParams`:
+ *
+ * - `%25` (`%`): a blanket `decodeURIComponent` would double-decode a value
+ *   like `"50%25discount"` and corrupt it into `"50%discount"`.
+ * - `%26` (`&`): decoding would turn a value `"a&b"` into a new param.
+ * - `%2B` (`+`): `URLSearchParams` parses `+` as a space, so decoding would
+ *   corrupt values containing literal `+`.
+ *
+ * Limitations: values that legitimately contain a comma, `<`, `>` or `=`
+ * cannot survive a round-trip with the multi-value protocol (comma is the
+ * value separator; the others are operator prefixes). Those characters are
+ * decoded here for readability; consumers should avoid putting them inside
+ * filter values.
+ */
+export const prettifyBrackets = (raw: string): string =>
+  raw
+    .replace(/%5B/gi, "[")
+    .replace(/%5D/gi, "]")
+    .replace(/%2C/gi, ",")
+    .replace(/%3C/gi, "<")
+    .replace(/%3E/gi, ">")
+    .replace(/%3D/gi, "=");
+
 const OPERATOR_PREFIXES: OperatorType[] = (
   Object.values(FilterOperator) as OperatorType[]
 )

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -9,10 +9,7 @@ import {
   type SearchParamsAdapterOptions,
   type Sort,
 } from "@/types";
-import {
-  compilePolicy,
-  type PolicyGate,
-} from "@/utils/searchParamsPolicy";
+import { compilePolicy, type PolicyGate } from "@/utils/searchParamsPolicy";
 
 export const DEFAULT_URL_KEYS: Record<ConfigurableURLKey, string> = {
   filter: "filter",
@@ -96,8 +93,14 @@ export const parseSearchParams = <
 
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
   const { pass } = policy ?? compilePolicy(options);
+  const forward = options?.aliases ?? {};
   const reverse = buildReverseAliases(options?.aliases);
   const aliasOf = (name: string): string => reverse.get(name) ?? name;
+  // Returns the alternate alias-space name (frontend if URL name is backend,
+  // backend if URL name is frontend). Used to make policy checks recognise
+  // both vocabularies — see JSDoc on SearchParamsAdapterOptions.allowed.
+  const altNameOf = (urlName: string): string =>
+    reverse.get(urlName) ?? forward[urlName] ?? urlName;
 
   const filters: Filter<Aliases>[] = [];
   const fields: Field[] = [];
@@ -108,7 +111,7 @@ export const parseSearchParams = <
   for (const [key, rawValue] of new URLSearchParams(trimmed).entries()) {
     const filterAttr = bracketedKey(key, keys.filter);
     if (filterAttr !== null) {
-      if (!pass("filters", filterAttr)) continue;
+      if (!pass("filters", filterAttr, altNameOf(filterAttr))) continue;
       const { operator, rest } = extractOperator(rawValue);
       filters.push({
         attribute: aliasOf(filterAttr) as Filter<Aliases>["attribute"],
@@ -138,7 +141,7 @@ export const parseSearchParams = <
       for (const item of splitCsv(rawValue)) {
         const desc = item.startsWith("-");
         const attr = desc ? item.slice(1) : item;
-        if (!pass("sorts", attr)) continue;
+        if (!pass("sorts", attr, altNameOf(attr))) continue;
         sorts.push({
           attribute: aliasOf(attr) as Sort<Aliases>["attribute"],
           direction: desc ? "desc" : "asc",

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -128,8 +128,15 @@ export const parseSearchParams = <
   const sorts: Sort<Aliases>[] = [];
   const includes: Include[] = [];
   const collectedParams: Record<string, (string | number)[]> = {};
+  const pagination: { page?: number; limit?: number } = {};
 
   for (const [key, rawValue] of new URLSearchParams(trimmed).entries()) {
+    if (key === "page" || key === "limit") {
+      const n = Number(rawValue);
+      if (Number.isFinite(n)) pagination[key] = n;
+      continue;
+    }
+
     const filterAttr = bracketedKey(key, keys.filter);
     if (filterAttr !== null) {
       if (!pass("filters", filterAttr, altNameOf(filterAttr))) continue;
@@ -187,6 +194,9 @@ export const parseSearchParams = <
   if (sorts.length > 0) result.sorts = sorts;
   if (includes.length > 0) result.includes = includes;
   if (Object.keys(collectedParams).length > 0) result.params = collectedParams;
+  if (pagination.page !== undefined || pagination.limit !== undefined) {
+    result.pagination = pagination;
+  }
 
   return result;
 };

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -9,6 +9,7 @@ import {
   type SearchParamsAdapterOptions,
   type Sort,
 } from "@/types";
+import { compilePolicy } from "@/utils/searchParamsPolicy";
 
 export const DEFAULT_URL_KEYS: Record<ConfigurableURLKey, string> = {
   filter: "filter",
@@ -23,28 +24,21 @@ const OPERATOR_PREFIXES: OperatorType[] = (
   .filter((op) => op !== FilterOperator.Equals)
   .sort((a, b) => b.length - a.length);
 
-const stripLeadingQuestion = (search: string): string =>
-  search.startsWith("?") ? search.slice(1) : search;
-
 const splitCsv = (raw: string): string[] => (raw === "" ? [] : raw.split(","));
 
 const extractOperator = (
   raw: string,
 ): { operator?: OperatorType; rest: string } => {
   for (const op of OPERATOR_PREFIXES) {
-    if (raw.startsWith(op)) {
-      return { operator: op as OperatorType, rest: raw.slice(op.length) };
-    }
+    if (raw.startsWith(op)) return { operator: op, rest: raw.slice(op.length) };
   }
   return { rest: raw };
 };
 
-const bracketedKey = (paramKey: string, prefix: string): string | null => {
-  if (!paramKey.startsWith(`${prefix}[`) || !paramKey.endsWith("]")) {
-    return null;
-  }
-  return paramKey.slice(prefix.length + 1, -1);
-};
+const bracketedKey = (paramKey: string, prefix: string): string | null =>
+  paramKey.startsWith(`${prefix}[`) && paramKey.endsWith("]")
+    ? paramKey.slice(prefix.length + 1, -1)
+    : null;
 
 const buildReverseAliases = (
   aliases: Record<string, string> | undefined,
@@ -62,15 +56,13 @@ export const parseSearchParams = <
   search: string,
   options?: SearchParamsAdapterOptions,
 ): Partial<GlobalState<Aliases>> => {
-  const trimmed = stripLeadingQuestion(search).trim();
+  const trimmed = search.replace(/^\?/, "").trim();
   if (trimmed === "") return {};
 
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
-  const allowed = new Set(options?.allowedParams ?? []);
-  const excluded = new Set(options?.excludeKeys ?? []);
-  const reverseAliases = buildReverseAliases(options?.aliases);
-  const aliasOf = (name: string): string => reverseAliases.get(name) ?? name;
-  const params = new URLSearchParams(trimmed);
+  const { pass } = compilePolicy(options);
+  const reverse = buildReverseAliases(options?.aliases);
+  const aliasOf = (name: string): string => reverse.get(name) ?? name;
 
   const filters: Filter<Aliases>[] = [];
   const fields: Field[] = [];
@@ -78,10 +70,10 @@ export const parseSearchParams = <
   const includes: Include[] = [];
   const collectedParams: Record<string, (string | number)[]> = {};
 
-  for (const [key, rawValue] of params.entries()) {
+  for (const [key, rawValue] of new URLSearchParams(trimmed).entries()) {
     const filterAttr = bracketedKey(key, keys.filter);
     if (filterAttr !== null) {
-      if (excluded.has(filterAttr)) continue;
+      if (!pass("filters", filterAttr)) continue;
       const { operator, rest } = extractOperator(rawValue);
       filters.push({
         attribute: aliasOf(filterAttr) as Filter<Aliases>["attribute"],
@@ -94,18 +86,15 @@ export const parseSearchParams = <
     const fieldEntity = bracketedKey(key, keys.fields);
     if (fieldEntity !== null) {
       for (const prop of splitCsv(rawValue)) {
-        if (excluded.has(prop) || excluded.has(`${fieldEntity}.${prop}`)) {
-          continue;
-        }
-        fields.push(`${fieldEntity}.${prop}`);
+        const full = `${fieldEntity}.${prop}`;
+        if (pass("fields", prop, full)) fields.push(full);
       }
       continue;
     }
 
     if (key === keys.fields) {
       for (const f of splitCsv(rawValue)) {
-        if (excluded.has(f)) continue;
-        fields.push(f);
+        if (pass("fields", f)) fields.push(f);
       }
       continue;
     }
@@ -114,7 +103,7 @@ export const parseSearchParams = <
       for (const item of splitCsv(rawValue)) {
         const desc = item.startsWith("-");
         const attr = desc ? item.slice(1) : item;
-        if (excluded.has(attr)) continue;
+        if (!pass("sorts", attr)) continue;
         sorts.push({
           attribute: aliasOf(attr) as Sort<Aliases>["attribute"],
           direction: desc ? "desc" : "asc",
@@ -125,15 +114,12 @@ export const parseSearchParams = <
 
     if (key === keys.include) {
       for (const inc of splitCsv(rawValue)) {
-        if (excluded.has(inc)) continue;
-        includes.push(inc);
+        if (pass("includes", inc)) includes.push(inc);
       }
       continue;
     }
 
-    if (allowed.has(key) && !excluded.has(key)) {
-      collectedParams[key] = splitCsv(rawValue);
-    }
+    if (pass("params", key)) collectedParams[key] = splitCsv(rawValue);
   }
 
   const result: Partial<GlobalState<Aliases>> = {};

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -1,8 +1,8 @@
 import {
+  FilterOperator,
   type ConfigurableURLKey,
   type Field,
   type Filter,
-  FilterOperator,
   type GlobalState,
   type Include,
   type OperatorType,
@@ -17,9 +17,6 @@ const DEFAULT_KEYS: Record<ConfigurableURLKey, string> = {
   fields: "fields",
 };
 
-// Longest first so multi-char operators (`<=`, `>=`, `<>`) win the prefix
-// race against their single-char prefixes (`<`, `>`). `Equals` is excluded
-// because the implicit operator carries no prefix on the wire.
 const OPERATOR_PREFIXES: OperatorType[] = (
   Object.values(FilterOperator) as OperatorType[]
 )

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -2,6 +2,7 @@ import {
   type ConfigurableURLKey,
   type Field,
   type Filter,
+  FilterOperator,
   type GlobalState,
   type Include,
   type OperatorType,
@@ -16,7 +17,14 @@ const DEFAULT_KEYS: Record<ConfigurableURLKey, string> = {
   fields: "fields",
 };
 
-const OPERATOR_PREFIXES: OperatorType[] = ["<>", "<=", ">=", "<", ">"];
+// Longest first so multi-char operators (`<=`, `>=`, `<>`) win the prefix
+// race against their single-char prefixes (`<`, `>`). `Equals` is excluded
+// because the implicit operator carries no prefix on the wire.
+const OPERATOR_PREFIXES: OperatorType[] = (
+  Object.values(FilterOperator) as OperatorType[]
+)
+  .filter((op) => op !== FilterOperator.Equals)
+  .sort((a, b) => b.length - a.length);
 
 const stripLeadingQuestion = (search: string): string =>
   search.startsWith("?") ? search.slice(1) : search;

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -66,10 +66,16 @@ const extractOperator = (
   return { rest: raw };
 };
 
-const bracketedKey = (paramKey: string, prefix: string): string | null =>
-  paramKey.startsWith(`${prefix}[`) && paramKey.endsWith("]")
-    ? paramKey.slice(prefix.length + 1, -1)
-    : null;
+const bracketedKey = (paramKey: string, prefix: string): string | null => {
+  if (!paramKey.startsWith(`${prefix}[`) || !paramKey.endsWith("]")) {
+    return null;
+  }
+  const inner = paramKey.slice(prefix.length + 1, -1);
+  // Reject nested brackets (e.g. `filter[a][b]`): the library does not
+  // model nested filters, and accepting them would let a malformed URL
+  // round-trip into a state attribute like `"a][b"`.
+  return inner.includes("[") || inner.includes("]") ? null : inner;
+};
 
 const buildReverseAliases = (
   aliases: Record<string, string> | undefined,

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -47,7 +47,7 @@ export const parseSearchParams = <
   search: string,
   options?: SearchParamsAdapterOptions,
 ): Partial<GlobalState<Aliases>> => {
-  const trimmed = stripLeadingQuestion(search ?? "").trim();
+  const trimmed = stripLeadingQuestion(search).trim();
   if (trimmed === "") return {};
 
   const keys = { ...DEFAULT_KEYS, ...(options?.keys ?? {}) };

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -114,8 +114,8 @@ export const parseSearchParams = <
 
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
   const { pass } = policy ?? compilePolicy(options);
-  const forward = options?.aliases ?? {};
-  const reverse = buildReverseAliases(options?.aliases);
+  const forward = options?.urlAliases ?? {};
+  const reverse = buildReverseAliases(options?.urlAliases);
   const aliasOf = (name: string): string => reverse.get(name) ?? name;
   // Returns the alternate alias-space name (frontend if URL name is backend,
   // backend if URL name is frontend). Used to make policy checks recognise

--- a/src/utils/parseSearchParams.ts
+++ b/src/utils/parseSearchParams.ts
@@ -9,7 +9,10 @@ import {
   type SearchParamsAdapterOptions,
   type Sort,
 } from "@/types";
-import { compilePolicy } from "@/utils/searchParamsPolicy";
+import {
+  compilePolicy,
+  type PolicyGate,
+} from "@/utils/searchParamsPolicy";
 
 export const DEFAULT_URL_KEYS: Record<ConfigurableURLKey, string> = {
   filter: "filter",
@@ -86,12 +89,13 @@ export const parseSearchParams = <
 >(
   search: string,
   options?: SearchParamsAdapterOptions,
+  policy?: PolicyGate,
 ): Partial<GlobalState<Aliases>> => {
   const trimmed = search.replace(/^\?/, "").trim();
   if (trimmed === "") return {};
 
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
-  const { pass } = compilePolicy(options);
+  const { pass } = policy ?? compilePolicy(options);
   const reverse = buildReverseAliases(options?.aliases);
   const aliasOf = (name: string): string => reverse.get(name) ?? name;
 

--- a/src/utils/searchParamsPolicy.ts
+++ b/src/utils/searchParamsPolicy.ts
@@ -1,0 +1,40 @@
+import { type SearchParamsAdapterOptions } from "@/types";
+
+const BUCKETS = ["filters", "sorts", "includes", "fields", "params"] as const;
+type Bucket = (typeof BUCKETS)[number];
+
+export interface PolicyGate {
+  /**
+   * Returns `true` iff the entry should be kept for `bucket`. Multiple
+   * candidate names are accepted for `fields` (short prop OR `entity.prop`).
+   *
+   * Rules (in order):
+   * 1. Any candidate in `excludeKeys[bucket]` → drop.
+   * 2. If `allowed[bucket]` is defined → at least one candidate must be in it.
+   * 3. Otherwise: bucket default applies — allow-all for filters/sorts/
+   *    includes/fields, deny-all for params (params is a catch-all so the
+   *    safe default is "nothing comes through unless explicitly listed").
+   */
+  pass: (bucket: Bucket, ...candidates: string[]) => boolean;
+}
+
+export const compilePolicy = (
+  options?: SearchParamsAdapterOptions,
+): PolicyGate => {
+  const allowed = {} as Record<Bucket, Set<string> | null>;
+  const excluded = {} as Record<Bucket, Set<string>>;
+  for (const b of BUCKETS) {
+    const allow = options?.allowed?.[b];
+    allowed[b] = allow ? new Set(allow) : null;
+    excluded[b] = new Set(options?.excludeKeys?.[b] ?? []);
+  }
+
+  return {
+    pass: (bucket, ...candidates) => {
+      if (candidates.some((c) => excluded[bucket].has(c))) return false;
+      const allow = allowed[bucket];
+      if (allow !== null) return candidates.some((c) => allow.has(c));
+      return bucket !== "params";
+    },
+  };
+};

--- a/src/utils/searchParamsPolicy.ts
+++ b/src/utils/searchParamsPolicy.ts
@@ -31,11 +31,17 @@ export const compilePolicy = (
   const allowed = {} as Record<Bucket, Set<string> | null>;
   const excluded = {} as Record<Bucket, Set<string>>;
   const omitted = {} as Record<Bucket, Set<string>>;
+  // `urlOmit[bucket]: ["*"]` is a wildcard meaning "drop every entry in
+  // this bucket". Tracked separately so `omit(...)` short-circuits without
+  // scanning candidates.
+  const omitAll = {} as Record<Bucket, boolean>;
   for (const b of BUCKETS) {
     const allow = options?.allowed?.[b];
     allowed[b] = allow ? new Set(allow) : null;
     excluded[b] = new Set(options?.excludeKeys?.[b] ?? []);
-    omitted[b] = new Set(options?.urlOmit?.[b] ?? []);
+    const omitList = options?.urlOmit?.[b] ?? [];
+    omitAll[b] = omitList.includes("*");
+    omitted[b] = new Set(omitList.filter((x) => x !== "*"));
   }
 
   return {
@@ -46,6 +52,6 @@ export const compilePolicy = (
       return bucket !== "params";
     },
     omit: (bucket, ...candidates) =>
-      candidates.some((c) => omitted[bucket].has(c)),
+      omitAll[bucket] || candidates.some((c) => omitted[bucket].has(c)),
   };
 };

--- a/src/utils/searchParamsPolicy.ts
+++ b/src/utils/searchParamsPolicy.ts
@@ -16,6 +16,13 @@ export interface PolicyGate {
    *    safe default is "nothing comes through unless explicitly listed").
    */
   pass: (bucket: Bucket, ...candidates: string[]) => boolean;
+  /**
+   * Returns `true` iff any candidate is listed in `urlOmit[bucket]`.
+   * Used by the serializer (writer-only) to skip entries that should
+   * stay in state but be hidden from the URL bar. The reader does not
+   * call this — `urlOmit` is intentionally write-only.
+   */
+  omit: (bucket: Bucket, ...candidates: string[]) => boolean;
 }
 
 export const compilePolicy = (
@@ -23,10 +30,12 @@ export const compilePolicy = (
 ): PolicyGate => {
   const allowed = {} as Record<Bucket, Set<string> | null>;
   const excluded = {} as Record<Bucket, Set<string>>;
+  const omitted = {} as Record<Bucket, Set<string>>;
   for (const b of BUCKETS) {
     const allow = options?.allowed?.[b];
     allowed[b] = allow ? new Set(allow) : null;
     excluded[b] = new Set(options?.excludeKeys?.[b] ?? []);
+    omitted[b] = new Set(options?.urlOmit?.[b] ?? []);
   }
 
   return {
@@ -36,5 +45,7 @@ export const compilePolicy = (
       if (allow !== null) return candidates.some((c) => allow.has(c));
       return bucket !== "params";
     },
+    omit: (bucket, ...candidates) =>
+      candidates.some((c) => omitted[bucket].has(c)),
   };
 };

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -20,9 +20,8 @@ const DELIMITER = ",";
  * API). Use it to keep the URL bar clean while feeding the backend the
  * context it needs.
  *
- * Pagination (`page` / `limit`) is intentionally NOT written — same contract
- * as the parser. Add them to `allowed.params` and set them via `setParam` if
- * you want them on the URL.
+ * Pagination (`page` / `limit`) is emitted unconditionally when set, so a
+ * link like `/list?page=3` round-trips back into `state.pagination`.
  */
 export const serializeSearchParams = <
   Aliases extends Record<string, string> | undefined = undefined,
@@ -94,6 +93,13 @@ export const serializeSearchParams = <
   for (const [k, v] of Object.entries(state.params ?? {})) {
     if (omit("params", k)) continue;
     if (pass("params", k)) sp.append(k, v.join(DELIMITER));
+  }
+
+  if (state.pagination?.page !== undefined) {
+    sp.append("page", String(state.pagination.page));
+  }
+  if (state.pagination?.limit !== undefined) {
+    sp.append("limit", String(state.pagination.limit));
   }
 
   const raw = sp.toString();

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -4,10 +4,7 @@ import {
   type SearchParamsAdapterOptions,
 } from "@/types";
 import { DEFAULT_URL_KEYS, prettifyBrackets } from "@/utils/parseSearchParams";
-import {
-  compilePolicy,
-  type PolicyGate,
-} from "@/utils/searchParamsPolicy";
+import { compilePolicy, type PolicyGate } from "@/utils/searchParamsPolicy";
 
 const DELIMITER = ",";
 
@@ -37,7 +34,7 @@ export const serializeSearchParams = <
 
   for (const filter of state.filters ?? []) {
     const wire = aliasOf(filter.attribute);
-    if (!pass("filters", wire)) continue;
+    if (!pass("filters", filter.attribute, wire)) continue;
     const op =
       filter.operator && filter.operator !== FilterOperator.Equals
         ? filter.operator
@@ -63,7 +60,7 @@ export const serializeSearchParams = <
   }
 
   const sortsKept = (state.sorts ?? []).filter((s) =>
-    pass("sorts", aliasOf(s.attribute)),
+    pass("sorts", s.attribute, aliasOf(s.attribute)),
   );
   if (sortsKept.length > 0) {
     sp.append(

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -15,6 +15,11 @@ const DELIMITER = ",";
  * symmetrically — anything outside the policy never reaches the URL, so
  * round-tripping with `parseSearchParams` is always safe.
  *
+ * Also honours `urlOmit`: entries listed there are dropped from the output
+ * but stay in the builder state (so `.build()` still emits them for the
+ * API). Use it to keep the URL bar clean while feeding the backend the
+ * context it needs.
+ *
  * Pagination (`page` / `limit`) is intentionally NOT written — same contract
  * as the parser. Add them to `allowed.params` and set them via `setParam` if
  * you want them on the URL.
@@ -29,11 +34,12 @@ export const serializeSearchParams = <
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
   const aliases = options?.urlAliases ?? state.aliases;
   const aliasOf = (name: string): string => aliases?.[name] ?? name;
-  const { pass } = policy ?? compilePolicy(options);
+  const { pass, omit } = policy ?? compilePolicy(options);
   const sp = new URLSearchParams();
 
   for (const filter of state.filters ?? []) {
     const wire = aliasOf(filter.attribute);
+    if (omit("filters", filter.attribute, wire)) continue;
     if (!pass("filters", filter.attribute, wire)) continue;
     const op =
       filter.operator && filter.operator !== FilterOperator.Equals
@@ -47,11 +53,13 @@ export const serializeSearchParams = <
   for (const field of state.fields ?? []) {
     const dotIdx = field.indexOf(".");
     if (dotIdx === -1) {
+      if (omit("fields", field)) continue;
       if (pass("fields", field)) bare.push(field);
       continue;
     }
     const entity = field.slice(0, dotIdx);
     const prop = field.slice(dotIdx + 1);
+    if (omit("fields", prop, field)) continue;
     if (pass("fields", prop, field)) (grouped[entity] ??= []).push(prop);
   }
   if (bare.length > 0) sp.append(keys.fields, bare.join(DELIMITER));
@@ -59,9 +67,12 @@ export const serializeSearchParams = <
     sp.append(`${keys.fields}[${entity}]`, props.join(DELIMITER));
   }
 
-  const sortsKept = (state.sorts ?? []).filter((s) =>
-    pass("sorts", s.attribute, aliasOf(s.attribute)),
-  );
+  const sortsKept = (state.sorts ?? []).filter((s) => {
+    const wire = aliasOf(s.attribute);
+    return (
+      !omit("sorts", s.attribute, wire) && pass("sorts", s.attribute, wire)
+    );
+  });
   if (sortsKept.length > 0) {
     sp.append(
       keys.sort,
@@ -73,14 +84,15 @@ export const serializeSearchParams = <
     );
   }
 
-  const includesKept = (state.includes ?? []).filter((i) =>
-    pass("includes", i),
+  const includesKept = (state.includes ?? []).filter(
+    (i) => !omit("includes", i) && pass("includes", i),
   );
   if (includesKept.length > 0) {
     sp.append(keys.include, includesKept.join(DELIMITER));
   }
 
   for (const [k, v] of Object.entries(state.params ?? {})) {
+    if (omit("params", k)) continue;
     if (pass("params", k)) sp.append(k, v.join(DELIMITER));
   }
 

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -27,7 +27,7 @@ export const serializeSearchParams = <
   policy?: PolicyGate,
 ): string => {
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
-  const aliases = options?.aliases ?? state.aliases;
+  const aliases = options?.urlAliases ?? state.aliases;
   const aliasOf = (name: string): string => aliases?.[name] ?? name;
   const { pass } = policy ?? compilePolicy(options);
   const sp = new URLSearchParams();

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -1,0 +1,92 @@
+import {
+  FilterOperator,
+  type GlobalState,
+  type SearchParamsAdapterOptions,
+} from "@/types";
+import { DEFAULT_URL_KEYS } from "@/utils/parseSearchParams";
+
+const DELIMITER = ",";
+
+const groupFields = (
+  fields: string[],
+): { bare: string[]; grouped: Record<string, string[]> } => {
+  const bare: string[] = [];
+  const grouped: Record<string, string[]> = {};
+  for (const field of fields) {
+    const dotIdx = field.indexOf(".");
+    if (dotIdx === -1) {
+      bare.push(field);
+      continue;
+    }
+    const entity = field.slice(0, dotIdx);
+    const prop = field.slice(dotIdx + 1);
+    grouped[entity] = grouped[entity] ?? [];
+    grouped[entity].push(prop);
+  }
+  return { bare, grouped };
+};
+
+/**
+ * Pure inverse of `parseSearchParams`. Turns a (partial) `GlobalState` into a
+ * query string using the same configurable keys (`filter`, `sort`, `include`,
+ * `fields`) and the same allowlist semantics for `params` (only keys listed in
+ * `allowedParams` are written, keeping the URL round-trippable with the
+ * matching `parseSearchParams` call).
+ *
+ * Pagination (`page` / `limit`) is intentionally NOT written — same contract
+ * as the parser. Add them to `allowedParams` and set them via `setParam` if
+ * you want them on the URL.
+ */
+export const serializeSearchParams = <
+  Aliases extends Record<string, string> | undefined = undefined,
+>(
+  state: Partial<GlobalState<Aliases>>,
+  options?: SearchParamsAdapterOptions,
+): string => {
+  const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
+  const allowed = new Set(options?.allowedParams ?? []);
+  const aliases = options?.aliases ?? state.aliases;
+  const aliasOf = (name: string): string => aliases?.[name] ?? name;
+  const sp = new URLSearchParams();
+
+  for (const filter of state.filters ?? []) {
+    const op =
+      filter.operator && filter.operator !== FilterOperator.Equals
+        ? filter.operator
+        : "";
+    sp.append(
+      `${keys.filter}[${aliasOf(filter.attribute)}]`,
+      op + filter.value.join(DELIMITER),
+    );
+  }
+
+  const { bare, grouped } = groupFields(state.fields ?? []);
+  if (bare.length > 0) sp.append(keys.fields, bare.join(DELIMITER));
+  for (const [entity, props] of Object.entries(grouped)) {
+    sp.append(`${keys.fields}[${entity}]`, props.join(DELIMITER));
+  }
+
+  const sorts = state.sorts ?? [];
+  if (sorts.length > 0) {
+    sp.append(
+      keys.sort,
+      sorts
+        .map(
+          (s) => `${s.direction === "desc" ? "-" : ""}${aliasOf(s.attribute)}`,
+        )
+        .join(DELIMITER),
+    );
+  }
+
+  const includes = state.includes ?? [];
+  if (includes.length > 0) {
+    sp.append(keys.include, includes.join(DELIMITER));
+  }
+
+  for (const [k, v] of Object.entries(state.params ?? {})) {
+    if (allowed.has(k)) sp.append(k, v.join(DELIMITER));
+  }
+
+  const raw = sp.toString();
+  return raw ? decodeURIComponent(raw) : "";
+};

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -3,7 +3,10 @@ import {
   type GlobalState,
   type SearchParamsAdapterOptions,
 } from "@/types";
-import { DEFAULT_URL_KEYS } from "@/utils/parseSearchParams";
+import {
+  DEFAULT_URL_KEYS,
+  prettifyBrackets,
+} from "@/utils/parseSearchParams";
 import { compilePolicy } from "@/utils/searchParamsPolicy";
 
 const DELIMITER = ",";
@@ -84,5 +87,5 @@ export const serializeSearchParams = <
   }
 
   const raw = sp.toString();
-  return raw ? decodeURIComponent(raw) : "";
+  return raw ? prettifyBrackets(raw) : "";
 };

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -3,11 +3,11 @@ import {
   type GlobalState,
   type SearchParamsAdapterOptions,
 } from "@/types";
+import { DEFAULT_URL_KEYS, prettifyBrackets } from "@/utils/parseSearchParams";
 import {
-  DEFAULT_URL_KEYS,
-  prettifyBrackets,
-} from "@/utils/parseSearchParams";
-import { compilePolicy } from "@/utils/searchParamsPolicy";
+  compilePolicy,
+  type PolicyGate,
+} from "@/utils/searchParamsPolicy";
 
 const DELIMITER = ",";
 
@@ -27,11 +27,12 @@ export const serializeSearchParams = <
 >(
   state: Partial<GlobalState<Aliases>>,
   options?: SearchParamsAdapterOptions,
+  policy?: PolicyGate,
 ): string => {
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
   const aliases = options?.aliases ?? state.aliases;
   const aliasOf = (name: string): string => aliases?.[name] ?? name;
-  const { pass } = compilePolicy(options);
+  const { pass } = policy ?? compilePolicy(options);
   const sp = new URLSearchParams();
 
   for (const filter of state.filters ?? []) {

--- a/src/utils/serializeSearchParams.ts
+++ b/src/utils/serializeSearchParams.ts
@@ -4,37 +4,19 @@ import {
   type SearchParamsAdapterOptions,
 } from "@/types";
 import { DEFAULT_URL_KEYS } from "@/utils/parseSearchParams";
+import { compilePolicy } from "@/utils/searchParamsPolicy";
 
 const DELIMITER = ",";
-
-const groupFields = (
-  fields: string[],
-): { bare: string[]; grouped: Record<string, string[]> } => {
-  const bare: string[] = [];
-  const grouped: Record<string, string[]> = {};
-  for (const field of fields) {
-    const dotIdx = field.indexOf(".");
-    if (dotIdx === -1) {
-      bare.push(field);
-      continue;
-    }
-    const entity = field.slice(0, dotIdx);
-    const prop = field.slice(dotIdx + 1);
-    grouped[entity] = grouped[entity] ?? [];
-    grouped[entity].push(prop);
-  }
-  return { bare, grouped };
-};
 
 /**
  * Pure inverse of `parseSearchParams`. Turns a (partial) `GlobalState` into a
  * query string using the same configurable keys (`filter`, `sort`, `include`,
- * `fields`) and the same allowlist semantics for `params` (only keys listed in
- * `allowedParams` are written, keeping the URL round-trippable with the
- * matching `parseSearchParams` call).
+ * `fields`) and the same `allowed` / `excludeKeys` policy applied
+ * symmetrically — anything outside the policy never reaches the URL, so
+ * round-tripping with `parseSearchParams` is always safe.
  *
  * Pagination (`page` / `limit`) is intentionally NOT written — same contract
- * as the parser. Add them to `allowedParams` and set them via `setParam` if
+ * as the parser. Add them to `allowed.params` and set them via `setParam` if
  * you want them on the URL.
  */
 export const serializeSearchParams = <
@@ -44,33 +26,45 @@ export const serializeSearchParams = <
   options?: SearchParamsAdapterOptions,
 ): string => {
   const keys = { ...DEFAULT_URL_KEYS, ...(options?.keys ?? {}) };
-  const allowed = new Set(options?.allowedParams ?? []);
   const aliases = options?.aliases ?? state.aliases;
   const aliasOf = (name: string): string => aliases?.[name] ?? name;
+  const { pass } = compilePolicy(options);
   const sp = new URLSearchParams();
 
   for (const filter of state.filters ?? []) {
+    const wire = aliasOf(filter.attribute);
+    if (!pass("filters", wire)) continue;
     const op =
       filter.operator && filter.operator !== FilterOperator.Equals
         ? filter.operator
         : "";
-    sp.append(
-      `${keys.filter}[${aliasOf(filter.attribute)}]`,
-      op + filter.value.join(DELIMITER),
-    );
+    sp.append(`${keys.filter}[${wire}]`, op + filter.value.join(DELIMITER));
   }
 
-  const { bare, grouped } = groupFields(state.fields ?? []);
+  const bare: string[] = [];
+  const grouped: Record<string, string[]> = {};
+  for (const field of state.fields ?? []) {
+    const dotIdx = field.indexOf(".");
+    if (dotIdx === -1) {
+      if (pass("fields", field)) bare.push(field);
+      continue;
+    }
+    const entity = field.slice(0, dotIdx);
+    const prop = field.slice(dotIdx + 1);
+    if (pass("fields", prop, field)) (grouped[entity] ??= []).push(prop);
+  }
   if (bare.length > 0) sp.append(keys.fields, bare.join(DELIMITER));
   for (const [entity, props] of Object.entries(grouped)) {
     sp.append(`${keys.fields}[${entity}]`, props.join(DELIMITER));
   }
 
-  const sorts = state.sorts ?? [];
-  if (sorts.length > 0) {
+  const sortsKept = (state.sorts ?? []).filter((s) =>
+    pass("sorts", aliasOf(s.attribute)),
+  );
+  if (sortsKept.length > 0) {
     sp.append(
       keys.sort,
-      sorts
+      sortsKept
         .map(
           (s) => `${s.direction === "desc" ? "-" : ""}${aliasOf(s.attribute)}`,
         )
@@ -78,13 +72,15 @@ export const serializeSearchParams = <
     );
   }
 
-  const includes = state.includes ?? [];
-  if (includes.length > 0) {
-    sp.append(keys.include, includes.join(DELIMITER));
+  const includesKept = (state.includes ?? []).filter((i) =>
+    pass("includes", i),
+  );
+  if (includesKept.length > 0) {
+    sp.append(keys.include, includesKept.join(DELIMITER));
   }
 
   for (const [k, v] of Object.entries(state.params ?? {})) {
-    if (allowed.has(k)) sp.append(k, v.join(DELIMITER));
+    if (pass("params", k)) sp.append(k, v.join(DELIMITER));
   }
 
   const raw = sp.toString();

--- a/tests/Units/builder.test.ts
+++ b/tests/Units/builder.test.ts
@@ -679,4 +679,89 @@ describe("Testing the class Builder", () => {
 
     expect(builder.build()).toBe("?filter[status]=inactive");
   });
+
+  describe("rehydrate()", () => {
+    it("re-runs adapter.read and replaces the data layer", () => {
+      let currentReadResult: Record<string, unknown> = {
+        filters: [{ attribute: "status", value: ["active"] }],
+      };
+      const builder = new Builder({
+        adapter: {
+          read: () => currentReadResult as never,
+        },
+      });
+
+      expect(builder.hasFilter("status")).toBe(true);
+
+      // External source "changed":
+      currentReadResult = {
+        filters: [{ attribute: "role", value: ["admin"] }],
+      };
+      builder.rehydrate();
+
+      expect(builder.hasFilter("status")).toBe(false);
+      expect(builder.hasFilter("role")).toBe(true);
+    });
+
+    it("clears a bucket when the new read result omits it", () => {
+      let result: Record<string, unknown> = {
+        includes: ["author"],
+      };
+      const builder = new Builder({
+        adapter: { read: () => result as never },
+      });
+      expect(builder.hasInclude("author")).toBe(true);
+
+      // Source no longer has includes.
+      result = {};
+      builder.rehydrate();
+
+      expect(builder.hasInclude("author")).toBe(false);
+    });
+
+    it("preserves config-layer fields (aliases, delimiters, useQuestionMark)", () => {
+      const builder = new Builder<{ name: "full_name" }>({
+        aliases: { name: "full_name" },
+        useQuestionMark: false,
+        adapter: {
+          read: () => ({
+            filters: [{ attribute: "name", value: ["x"] }],
+          }),
+        },
+      });
+
+      builder.rehydrate();
+
+      expect(builder.build()).toBe("filter[full_name]=x"); // aliases applied, no leading ?
+    });
+
+    it("is a no-op when no adapter was configured", () => {
+      const builder = new Builder({
+        filters: [{ attribute: "status", value: ["active"] }],
+      });
+      expect(builder.hasFilter("status")).toBe(true);
+
+      builder.rehydrate();
+
+      expect(builder.hasFilter("status")).toBe(true);
+    });
+
+    it("fires adapter.write after rehydrating", () => {
+      const write = vi.fn();
+      let result: Record<string, unknown> = {};
+      const builder = new Builder({
+        adapter: {
+          read: () => result as never,
+          write,
+        },
+      });
+
+      const callsAfterMount = write.mock.calls.length;
+
+      result = { filters: [{ attribute: "x", value: ["1"] }] };
+      builder.rehydrate();
+
+      expect(write.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    });
+  });
 });

--- a/tests/Units/hooks/useQueryBuilder.test.tsx
+++ b/tests/Units/hooks/useQueryBuilder.test.tsx
@@ -102,7 +102,7 @@ describe("useQueryBuilder", () => {
       source: () =>
         "?filt[status]=active&srt=-name&inc=user&fld[user]=id,email&locale=es",
       keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
-      allowedParams: ["locale"],
+      allowed: { params: ["locale"] },
     });
 
     const { result } = renderHook(() => useQueryBuilder({ adapter }));

--- a/tests/Units/hooks/useQueryBuilder.test.tsx
+++ b/tests/Units/hooks/useQueryBuilder.test.tsx
@@ -112,11 +112,15 @@ describe("useQueryBuilder", () => {
     );
   });
 
-  it("should call adapter.write on every state mutation", () => {
+  it("should call adapter.write once on mount and on every state mutation", () => {
     const write = vi.fn();
     const { result } = renderHook(() =>
       useQueryBuilder({ adapter: { read: () => ({}), write } }),
     );
+
+    // First call fires at construction to normalise the external source
+    // against the final state (defaults, urlOmit, etc.).
+    expect(write).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.filter("status", "active");
@@ -125,7 +129,8 @@ describe("useQueryBuilder", () => {
       result.current.sort("name");
     });
 
-    expect(write).toHaveBeenCalledTimes(2);
+    // +1 per mutation.
+    expect(write).toHaveBeenCalledTimes(3);
     expect(write).toHaveBeenLastCalledWith(
       expect.objectContaining({
         filters: [{ attribute: "status", value: ["active"] }],

--- a/tests/Units/hooks/useQueryBuilder.test.tsx
+++ b/tests/Units/hooks/useQueryBuilder.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
+import { createSearchParamsAdapter } from "@/adapters/searchParams";
 import { useQueryBuilder } from "@/hooks/useQueryBuilder";
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 describe("useQueryBuilder", () => {
   it("should return a QueryBuilder instance with empty state", () => {
@@ -63,6 +64,74 @@ describe("useQueryBuilder", () => {
     });
 
     expect(result.current.build()).toBe("?filter[status]=active");
+  });
+
+  it("should invoke adapter.read exactly once across re-renders", () => {
+    const read = vi.fn(() => ({
+      filters: [{ attribute: "status", value: ["active"] }],
+    }));
+
+    const { result, rerender } = renderHook(() =>
+      useQueryBuilder({ adapter: { read } }),
+    );
+
+    rerender();
+    rerender();
+
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(result.current.build()).toBe("?filter[status]=active");
+  });
+
+  it("should let explicit config win over adapter.read", () => {
+    const { result } = renderHook(() =>
+      useQueryBuilder({
+        adapter: {
+          read: () => ({
+            filters: [{ attribute: "status", value: ["from-adapter"] }],
+          }),
+        },
+        filters: [{ attribute: "status", value: ["from-config"] }],
+      }),
+    );
+
+    expect(result.current.build()).toBe("?filter[status]=from-config");
+  });
+
+  it("should hydrate via createSearchParamsAdapter with custom keys", () => {
+    const adapter = createSearchParamsAdapter({
+      source: () =>
+        "?filt[status]=active&srt=-name&inc=user&fld[user]=id,email&locale=es",
+      keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
+      allowedParams: ["locale"],
+    });
+
+    const { result } = renderHook(() => useQueryBuilder({ adapter }));
+
+    expect(result.current.build()).toBe(
+      "?filter[status]=active&fields[user]=id,email&sort=-name&include=user&locale=es",
+    );
+  });
+
+  it("should call adapter.write on every state mutation", () => {
+    const write = vi.fn();
+    const { result } = renderHook(() =>
+      useQueryBuilder({ adapter: { read: () => ({}), write } }),
+    );
+
+    act(() => {
+      result.current.filter("status", "active");
+    });
+    act(() => {
+      result.current.sort("name");
+    });
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        filters: [{ attribute: "status", value: ["active"] }],
+        sorts: [{ attribute: "name", direction: "asc" }],
+      }),
+    );
   });
 
   it("should work with aliases", () => {

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -89,6 +89,18 @@ describe("parseSearchParams", () => {
     ).toEqual({ params: { locale: ["es"], tenant: ["acme"] } });
   });
 
+  it("accepts an externally pre-compiled policy as the 3rd argument", async () => {
+    const { compilePolicy } = await import("@/utils/searchParamsPolicy");
+    const policy = compilePolicy({ allowed: { filters: ["status"] } });
+    expect(
+      parseSearchParams(
+        "?filter[status]=active&filter[is_admin]=true",
+        undefined,
+        policy,
+      ),
+    ).toEqual({ filters: [{ attribute: "status", value: ["active"] }] });
+  });
+
   describe("aliases (reverse lookup)", () => {
     it("rewrites filter and sort attributes from backend → frontend", () => {
       expect(

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -1,97 +1,85 @@
+import { type GlobalState } from "@/types";
 import { parseSearchParams } from "@/utils/parseSearchParams";
 import { describe, expect, it } from "vitest";
 
 describe("parseSearchParams", () => {
-  it("returns an empty object for an empty search string", () => {
-    expect(parseSearchParams("")).toEqual({});
-    expect(parseSearchParams("?")).toEqual({});
-  });
+  it.each([[""], ["?"], ["?unknown=x"]])(
+    "returns {} for non-recognised input (%j)",
+    (input) => {
+      expect(parseSearchParams(input)).toEqual({});
+    },
+  );
 
-  it("parses default filter keys with comma-separated values", () => {
-    const result = parseSearchParams(
+  it.each<[string, string, Partial<GlobalState>]>([
+    [
+      "filters with single and multi-value",
       "?filter[status]=active,pending&filter[name]=John",
-    );
-
-    expect(result.filters).toEqual([
-      { attribute: "status", value: ["active", "pending"] },
-      { attribute: "name", value: ["John"] },
-    ]);
-  });
-
-  it("recovers the operator prefix from a filter value", () => {
-    const result = parseSearchParams("?filter[age]=>=18&filter[score]=<>0");
-
-    expect(result.filters).toEqual([
-      { attribute: "age", value: ["18"], operator: ">=" },
-      { attribute: "score", value: ["0"], operator: "<>" },
-    ]);
-  });
-
-  it("parses sort with desc prefix and asc default", () => {
-    const result = parseSearchParams("?sort=-created_at,name");
-
-    expect(result.sorts).toEqual([
-      { attribute: "created_at", direction: "desc" },
-      { attribute: "name", direction: "asc" },
-    ]);
-  });
-
-  it("parses include into a flat array", () => {
-    const result = parseSearchParams("?include=user,team");
-    expect(result.includes).toEqual(["user", "team"]);
-  });
-
-  it("parses both bare and bracketed fields into dotted notation", () => {
-    const result = parseSearchParams("?fields=id&fields[user]=name,email");
-    expect(result.fields).toEqual(["id", "user.name", "user.email"]);
+      {
+        filters: [
+          { attribute: "status", value: ["active", "pending"] },
+          { attribute: "name", value: ["John"] },
+        ],
+      },
+    ],
+    [
+      "filters with operator prefixes",
+      "?filter[age]=>=18&filter[score]=<>0",
+      {
+        filters: [
+          { attribute: "age", value: ["18"], operator: ">=" },
+          { attribute: "score", value: ["0"], operator: "<>" },
+        ],
+      },
+    ],
+    [
+      "filter keys with empty value (with and without operator)",
+      "?filter[status]=&filter[score]=>=",
+      {
+        filters: [
+          { attribute: "status", value: [] },
+          { attribute: "score", value: [], operator: ">=" },
+        ],
+      },
+    ],
+    [
+      "sort with desc prefix and asc default",
+      "?sort=-created_at,name",
+      {
+        sorts: [
+          { attribute: "created_at", direction: "desc" },
+          { attribute: "name", direction: "asc" },
+        ],
+      },
+    ],
+    ["include into a flat array", "?include=user,team", { includes: ["user", "team"] }],
+    [
+      "bare and bracketed fields collapsed into dotted notation",
+      "?fields=id&fields[user]=name,email",
+      { fields: ["id", "user.name", "user.email"] },
+    ],
+  ])("parses %s", (_label, input, expected) => {
+    expect(parseSearchParams(input)).toEqual(expected);
   });
 
   it("honours custom URL keys", () => {
-    const result = parseSearchParams(
-      "?filt[status]=active&srt=-name&inc=user&fld[user]=id",
-      {
-        keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
-      },
-    );
-
-    expect(result.filters).toEqual([
-      { attribute: "status", value: ["active"] },
-    ]);
-    expect(result.sorts).toEqual([{ attribute: "name", direction: "desc" }]);
-    expect(result.includes).toEqual(["user"]);
-    expect(result.fields).toEqual(["user.id"]);
-  });
-
-  it("ignores unknown params when no allowlist is provided", () => {
-    const result = parseSearchParams("?locale=es&tenant=acme");
-    expect(result.params).toBeUndefined();
-  });
-
-  it("captures only allowlisted unknown params", () => {
-    const result = parseSearchParams("?locale=es&tenant=acme&spy=1", {
-      allowedParams: ["locale", "tenant"],
-    });
-
-    expect(result.params).toEqual({
-      locale: ["es"],
-      tenant: ["acme"],
+    expect(
+      parseSearchParams(
+        "?filt[status]=active&srt=-name&inc=user&fld[user]=id",
+        { keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" } },
+      ),
+    ).toEqual({
+      filters: [{ attribute: "status", value: ["active"] }],
+      sorts: [{ attribute: "name", direction: "desc" }],
+      includes: ["user"],
+      fields: ["user.id"],
     });
   });
 
-  it("does not return empty collections when nothing was parsed", () => {
-    const result = parseSearchParams("?unknown=x");
-    expect(result).toEqual({});
-  });
-
-  it("returns an empty value array for filter keys with no value", () => {
-    const result = parseSearchParams("?filter[status]=");
-    expect(result.filters).toEqual([{ attribute: "status", value: [] }]);
-  });
-
-  it("returns an empty value array for filter keys with an operator and no value", () => {
-    const result = parseSearchParams("?filter[score]=>=");
-    expect(result.filters).toEqual([
-      { attribute: "score", value: [], operator: ">=" },
-    ]);
+  it("captures only allowlisted unknown params (ignores the rest)", () => {
+    expect(
+      parseSearchParams("?locale=es&tenant=acme&spy=1", {
+        allowedParams: ["locale", "tenant"],
+      }),
+    ).toEqual({ params: { locale: ["es"], tenant: ["acme"] } });
   });
 });

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -198,6 +198,64 @@ describe("parseSearchParams", () => {
     });
   });
 
+  describe("policy is alias-aware (matches both frontend and backend names)", () => {
+    const aliases = { userName: "name", adminFlag: "is_admin" };
+
+    it("DX: allowed.filters with FRONTEND name hydrates a URL with backend name", () => {
+      // Dev writes the name they think in (frontend), URL has the wire name.
+      expect(
+        parseSearchParams("?filter[name]=John", {
+          aliases,
+          allowed: { filters: ["userName"] },
+        }),
+      ).toEqual({ filters: [{ attribute: "userName", value: ["John"] }] });
+    });
+
+    it("DX: allowed.filters with BACKEND name also works (existing behaviour)", () => {
+      expect(
+        parseSearchParams("?filter[name]=John", {
+          aliases,
+          allowed: { filters: ["name"] },
+        }),
+      ).toEqual({ filters: [{ attribute: "userName", value: ["John"] }] });
+    });
+
+    it("security: excludeKeys.filters with backend name blocks attacker using FRONTEND name", () => {
+      // Attacker tries to bypass `is_admin` denylist by using the alias key.
+      expect(
+        parseSearchParams("?filter[adminFlag]=true", {
+          aliases,
+          excludeKeys: { filters: ["is_admin"] },
+        }),
+      ).toEqual({});
+    });
+
+    it("security: excludeKeys.filters with frontend name still blocks backend URL form", () => {
+      expect(
+        parseSearchParams("?filter[is_admin]=true", {
+          aliases,
+          excludeKeys: { filters: ["adminFlag"] },
+        }),
+      ).toEqual({});
+    });
+
+    it("sorts get the same dual-name treatment", () => {
+      expect(
+        parseSearchParams("?sort=-name", {
+          aliases,
+          allowed: { sorts: ["userName"] },
+        }),
+      ).toEqual({ sorts: [{ attribute: "userName", direction: "desc" }] });
+
+      expect(
+        parseSearchParams("?sort=adminFlag", {
+          aliases,
+          excludeKeys: { sorts: ["is_admin"] },
+        }),
+      ).toEqual({});
+    });
+  });
+
   describe("excludeKeys (defense in depth, per bucket)", () => {
     it("only blocks within the bucket it is declared for", () => {
       // 'password' is dangerous as a filter but legitimate as a field

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -133,6 +133,34 @@ describe("parseSearchParams", () => {
     });
   });
 
+  describe("pagination", () => {
+    it("hydrates page and limit from the URL", () => {
+      expect(parseSearchParams("?page=3&limit=20")).toEqual({
+        pagination: { page: 3, limit: 20 },
+      });
+    });
+
+    it("hydrates page only when limit is absent", () => {
+      expect(parseSearchParams("?page=5")).toEqual({
+        pagination: { page: 5 },
+      });
+    });
+
+    it("ignores non-numeric values", () => {
+      expect(parseSearchParams("?page=abc&limit=20")).toEqual({
+        pagination: { limit: 20 },
+      });
+    });
+
+    it("does not also collect page/limit into params bucket", () => {
+      expect(
+        parseSearchParams("?page=2", {
+          allowed: { params: ["page"] }, // would otherwise capture it
+        }),
+      ).toEqual({ pagination: { page: 2 } });
+    });
+  });
+
   it("accepts an externally pre-compiled policy as the 3rd argument", async () => {
     const { compilePolicy } = await import("@/utils/searchParamsPolicy");
     const policy = compilePolicy({ allowed: { filters: ["status"] } });

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -82,4 +82,16 @@ describe("parseSearchParams", () => {
     const result = parseSearchParams("?unknown=x");
     expect(result).toEqual({});
   });
+
+  it("returns an empty value array for filter keys with no value", () => {
+    const result = parseSearchParams("?filter[status]=");
+    expect(result.filters).toEqual([{ attribute: "status", value: [] }]);
+  });
+
+  it("returns an empty value array for filter keys with an operator and no value", () => {
+    const result = parseSearchParams("?filter[score]=>=");
+    expect(result.filters).toEqual([
+      { attribute: "score", value: [], operator: ">=" },
+    ]);
+  });
 });

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -89,6 +89,20 @@ describe("parseSearchParams", () => {
     ).toEqual({ params: { locale: ["es"], tenant: ["acme"] } });
   });
 
+  describe("malformed URL keys", () => {
+    it("ignores filter[a][b] (nested brackets are not part of the protocol)", () => {
+      expect(
+        parseSearchParams("?filter[a][b]=x&filter[status]=active"),
+      ).toEqual({ filters: [{ attribute: "status", value: ["active"] }] });
+    });
+
+    it("ignores fields[a][b] the same way", () => {
+      expect(parseSearchParams("?fields[user][nested]=name&fields=id")).toEqual(
+        { fields: ["id"] },
+      );
+    });
+  });
+
   describe("repeated URL params (?sort=a&sort=b)", () => {
     it("accumulates sort entries the same way as the CSV form", () => {
       // ?sort=name&sort=-created_at  is equivalent in result to

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -89,6 +89,36 @@ describe("parseSearchParams", () => {
     ).toEqual({ params: { locale: ["es"], tenant: ["acme"] } });
   });
 
+  describe("repeated URL params (?sort=a&sort=b)", () => {
+    it("accumulates sort entries the same way as the CSV form", () => {
+      // ?sort=name&sort=-created_at  is equivalent in result to
+      // ?sort=name,-created_at — both produce two sort entries.
+      expect(parseSearchParams("?sort=name&sort=-created_at")).toEqual({
+        sorts: [
+          { attribute: "name", direction: "asc" },
+          { attribute: "created_at", direction: "desc" },
+        ],
+      });
+    });
+
+    it("accumulates include entries across repeated params", () => {
+      expect(parseSearchParams("?include=author&include=tags")).toEqual({
+        includes: ["author", "tags"],
+      });
+    });
+
+    it("treats the same filter key twice as two separate filter entries", () => {
+      expect(
+        parseSearchParams("?filter[status]=active&filter[status]=pending"),
+      ).toEqual({
+        filters: [
+          { attribute: "status", value: ["active"] },
+          { attribute: "status", value: ["pending"] },
+        ],
+      });
+    });
+  });
+
   it("accepts an externally pre-compiled policy as the 3rd argument", async () => {
     const { compilePolicy } = await import("@/utils/searchParamsPolicy");
     const policy = compilePolicy({ allowed: { filters: ["status"] } });

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -51,7 +51,11 @@ describe("parseSearchParams", () => {
         ],
       },
     ],
-    ["include into a flat array", "?include=user,team", { includes: ["user", "team"] }],
+    [
+      "include into a flat array",
+      "?include=user,team",
+      { includes: ["user", "team"] },
+    ],
     [
       "bare and bracketed fields collapsed into dotted notation",
       "?fields=id&fields[user]=name,email",
@@ -65,7 +69,9 @@ describe("parseSearchParams", () => {
     expect(
       parseSearchParams(
         "?filt[status]=active&srt=-name&inc=user&fld[user]=id",
-        { keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" } },
+        {
+          keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
+        },
       ),
     ).toEqual({
       filters: [{ attribute: "status", value: ["active"] }],

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -88,4 +88,82 @@ describe("parseSearchParams", () => {
       }),
     ).toEqual({ params: { locale: ["es"], tenant: ["acme"] } });
   });
+
+  describe("aliases (reverse lookup)", () => {
+    it("rewrites filter and sort attributes from backend → frontend", () => {
+      expect(
+        parseSearchParams("?filter[name]=John&sort=-created_at", {
+          aliases: { userName: "name", createdAt: "created_at" },
+        }),
+      ).toEqual({
+        filters: [{ attribute: "userName", value: ["John"] }],
+        sorts: [{ attribute: "createdAt", direction: "desc" }],
+      });
+    });
+
+    it("leaves attributes untouched when no alias matches", () => {
+      expect(
+        parseSearchParams("?filter[unknown]=x", {
+          aliases: { userName: "name" },
+        }),
+      ).toEqual({ filters: [{ attribute: "unknown", value: ["x"] }] });
+    });
+
+    it("first-wins on alias collisions (multiple frontends → same backend)", () => {
+      expect(
+        parseSearchParams("?filter[name]=John", {
+          aliases: { userName: "name", fullName: "name" },
+        }),
+      ).toEqual({ filters: [{ attribute: "userName", value: ["John"] }] });
+    });
+  });
+
+  describe("excludeKeys (defense in depth)", () => {
+    it("drops filters whose attribute is in the denylist", () => {
+      expect(
+        parseSearchParams(
+          "?filter[is_admin]=true&filter[status]=active",
+          { excludeKeys: ["is_admin"] },
+        ),
+      ).toEqual({ filters: [{ attribute: "status", value: ["active"] }] });
+    });
+
+    it("drops sorts and includes whose attribute is in the denylist", () => {
+      expect(
+        parseSearchParams("?sort=-is_admin,name&include=secret,user", {
+          excludeKeys: ["is_admin", "secret"],
+        }),
+      ).toEqual({
+        sorts: [{ attribute: "name", direction: "asc" }],
+        includes: ["user"],
+      });
+    });
+
+    it("drops fields (bare and bracketed) that match the denylist", () => {
+      expect(
+        parseSearchParams(
+          "?fields=id,password&fields[user]=name,password",
+          { excludeKeys: ["password"] },
+        ),
+      ).toEqual({ fields: ["id", "user.name"] });
+    });
+
+    it("denylist overrides the params allowlist", () => {
+      expect(
+        parseSearchParams("?locale=es&secret=leak", {
+          allowedParams: ["locale", "secret"],
+          excludeKeys: ["secret"],
+        }),
+      ).toEqual({ params: { locale: ["es"] } });
+    });
+
+    it("applies denylist BEFORE reverse alias (matches the backend name)", () => {
+      expect(
+        parseSearchParams("?filter[is_admin]=true", {
+          aliases: { isAdmin: "is_admin" },
+          excludeKeys: ["is_admin"],
+        }),
+      ).toEqual({});
+    });
+  });
 });

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -1,0 +1,85 @@
+import { parseSearchParams } from "@/utils/parseSearchParams";
+import { describe, expect, it } from "vitest";
+
+describe("parseSearchParams", () => {
+  it("returns an empty object for an empty search string", () => {
+    expect(parseSearchParams("")).toEqual({});
+    expect(parseSearchParams("?")).toEqual({});
+  });
+
+  it("parses default filter keys with comma-separated values", () => {
+    const result = parseSearchParams(
+      "?filter[status]=active,pending&filter[name]=John",
+    );
+
+    expect(result.filters).toEqual([
+      { attribute: "status", value: ["active", "pending"] },
+      { attribute: "name", value: ["John"] },
+    ]);
+  });
+
+  it("recovers the operator prefix from a filter value", () => {
+    const result = parseSearchParams("?filter[age]=>=18&filter[score]=<>0");
+
+    expect(result.filters).toEqual([
+      { attribute: "age", value: ["18"], operator: ">=" },
+      { attribute: "score", value: ["0"], operator: "<>" },
+    ]);
+  });
+
+  it("parses sort with desc prefix and asc default", () => {
+    const result = parseSearchParams("?sort=-created_at,name");
+
+    expect(result.sorts).toEqual([
+      { attribute: "created_at", direction: "desc" },
+      { attribute: "name", direction: "asc" },
+    ]);
+  });
+
+  it("parses include into a flat array", () => {
+    const result = parseSearchParams("?include=user,team");
+    expect(result.includes).toEqual(["user", "team"]);
+  });
+
+  it("parses both bare and bracketed fields into dotted notation", () => {
+    const result = parseSearchParams("?fields=id&fields[user]=name,email");
+    expect(result.fields).toEqual(["id", "user.name", "user.email"]);
+  });
+
+  it("honours custom URL keys", () => {
+    const result = parseSearchParams(
+      "?filt[status]=active&srt=-name&inc=user&fld[user]=id",
+      {
+        keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
+      },
+    );
+
+    expect(result.filters).toEqual([
+      { attribute: "status", value: ["active"] },
+    ]);
+    expect(result.sorts).toEqual([{ attribute: "name", direction: "desc" }]);
+    expect(result.includes).toEqual(["user"]);
+    expect(result.fields).toEqual(["user.id"]);
+  });
+
+  it("ignores unknown params when no allowlist is provided", () => {
+    const result = parseSearchParams("?locale=es&tenant=acme");
+    expect(result.params).toBeUndefined();
+  });
+
+  it("captures only allowlisted unknown params", () => {
+    const result = parseSearchParams("?locale=es&tenant=acme&spy=1", {
+      allowedParams: ["locale", "tenant"],
+    });
+
+    expect(result.params).toEqual({
+      locale: ["es"],
+      tenant: ["acme"],
+    });
+  });
+
+  it("does not return empty collections when nothing was parsed", () => {
+    const result = parseSearchParams("?unknown=x");
+    expect(result).toEqual({});
+  });
+});

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -84,7 +84,7 @@ describe("parseSearchParams", () => {
   it("captures only allowlisted unknown params (ignores the rest)", () => {
     expect(
       parseSearchParams("?locale=es&tenant=acme&spy=1", {
-        allowedParams: ["locale", "tenant"],
+        allowed: { params: ["locale", "tenant"] },
       }),
     ).toEqual({ params: { locale: ["es"], tenant: ["acme"] } });
   });
@@ -118,20 +118,100 @@ describe("parseSearchParams", () => {
     });
   });
 
-  describe("excludeKeys (defense in depth)", () => {
-    it("drops filters whose attribute is in the denylist", () => {
+  describe("allowed (allowlist per bucket)", () => {
+    it("undefined bucket → default behavior (allow-all for filters/sorts/etc, deny-all for params)", () => {
+      expect(
+        parseSearchParams("?filter[anything]=x&sort=anything&locale=es"),
+      ).toEqual({
+        filters: [{ attribute: "anything", value: ["x"] }],
+        sorts: [{ attribute: "anything", direction: "asc" }],
+        // locale dropped because allowed.params is undefined (deny-all)
+      });
+    });
+
+    it("defined bucket → only listed entries pass", () => {
       expect(
         parseSearchParams(
-          "?filter[is_admin]=true&filter[status]=active",
-          { excludeKeys: ["is_admin"] },
+          "?filter[status]=active&filter[is_admin]=true&filter[role]=admin",
+          { allowed: { filters: ["status", "role"] } },
         ),
+      ).toEqual({
+        filters: [
+          { attribute: "status", value: ["active"] },
+          { attribute: "role", value: ["admin"] },
+        ],
+      });
+    });
+
+    it("allowlists are independent per bucket", () => {
+      expect(
+        parseSearchParams("?filter[name]=x&sort=name&sort=created_at", {
+          allowed: { filters: ["name"], sorts: ["created_at"] },
+        }),
+      ).toEqual({
+        filters: [{ attribute: "name", value: ["x"] }],
+        sorts: [{ attribute: "created_at", direction: "asc" }],
+      });
+    });
+
+    it("includes allowlist filters incoming relations", () => {
+      expect(
+        parseSearchParams("?include=author,secret_log,tags", {
+          allowed: { includes: ["author", "tags"] },
+        }),
+      ).toEqual({ includes: ["author", "tags"] });
+    });
+
+    it("fields allowlist matches both short prop and entity.prop forms", () => {
+      expect(
+        parseSearchParams(
+          "?fields=id,password&fields[user]=name,email,password",
+          { allowed: { fields: ["id", "name", "user.email"] } },
+        ),
+      ).toEqual({ fields: ["id", "user.name", "user.email"] });
+    });
+
+    it("excludeKeys still wins when both are set on the same bucket", () => {
+      expect(
+        parseSearchParams("?filter[name]=x&filter[status]=y&filter[role]=z", {
+          allowed: { filters: ["name", "status", "role"] },
+          excludeKeys: { filters: ["status"] },
+        }),
+      ).toEqual({
+        filters: [
+          { attribute: "name", value: ["x"] },
+          { attribute: "role", value: ["z"] },
+        ],
+      });
+    });
+  });
+
+  describe("excludeKeys (defense in depth, per bucket)", () => {
+    it("only blocks within the bucket it is declared for", () => {
+      // 'password' is dangerous as a filter but legitimate as a field
+      expect(
+        parseSearchParams(
+          "?filter[password]=anything&fields[user]=name,password",
+          { excludeKeys: { filters: ["password"] } },
+        ),
+      ).toEqual({ fields: ["user.name", "user.password"] });
+    });
+
+    it("drops filters in the filters bucket only", () => {
+      expect(
+        parseSearchParams("?filter[is_admin]=true&filter[status]=active", {
+          excludeKeys: { filters: ["is_admin"] },
+        }),
       ).toEqual({ filters: [{ attribute: "status", value: ["active"] }] });
     });
 
-    it("drops sorts and includes whose attribute is in the denylist", () => {
+    it("drops sorts and includes via their own bucket lists", () => {
       expect(
         parseSearchParams("?sort=-is_admin,name&include=secret,user", {
-          excludeKeys: ["is_admin", "secret"],
+          excludeKeys: {
+            sorts: ["is_admin"],
+            includes: ["secret"],
+          },
         }),
       ).toEqual({
         sorts: [{ attribute: "name", direction: "asc" }],
@@ -139,31 +219,39 @@ describe("parseSearchParams", () => {
       });
     });
 
-    it("drops fields (bare and bracketed) that match the denylist", () => {
+    it("drops fields by short prop name or by entity.prop form", () => {
       expect(
         parseSearchParams(
-          "?fields=id,password&fields[user]=name,password",
-          { excludeKeys: ["password"] },
+          "?fields=id,password&fields[user]=name,password&fields[admin]=role",
+          { excludeKeys: { fields: ["password", "admin.role"] } },
         ),
       ).toEqual({ fields: ["id", "user.name"] });
     });
 
-    it("denylist overrides the params allowlist", () => {
+    it("params bucket: excludeKeys overrides the allowlist", () => {
       expect(
         parseSearchParams("?locale=es&secret=leak", {
-          allowedParams: ["locale", "secret"],
-          excludeKeys: ["secret"],
+          allowed: { params: ["locale", "secret"] },
+          excludeKeys: { params: ["secret"] },
         }),
       ).toEqual({ params: { locale: ["es"] } });
     });
 
-    it("applies denylist BEFORE reverse alias (matches the backend name)", () => {
+    it("matches the raw backend name BEFORE reverse alias", () => {
       expect(
         parseSearchParams("?filter[is_admin]=true", {
           aliases: { isAdmin: "is_admin" },
-          excludeKeys: ["is_admin"],
+          excludeKeys: { filters: ["is_admin"] },
         }),
       ).toEqual({});
+    });
+
+    it("does not leak across buckets (sorts list does not affect filters)", () => {
+      expect(
+        parseSearchParams("?filter[name]=x&sort=name", {
+          excludeKeys: { sorts: ["name"] },
+        }),
+      ).toEqual({ filters: [{ attribute: "name", value: ["x"] }] });
     });
   });
 });

--- a/tests/Units/parseSearchParams.test.ts
+++ b/tests/Units/parseSearchParams.test.ts
@@ -149,7 +149,7 @@ describe("parseSearchParams", () => {
     it("rewrites filter and sort attributes from backend → frontend", () => {
       expect(
         parseSearchParams("?filter[name]=John&sort=-created_at", {
-          aliases: { userName: "name", createdAt: "created_at" },
+          urlAliases: { userName: "name", createdAt: "created_at" },
         }),
       ).toEqual({
         filters: [{ attribute: "userName", value: ["John"] }],
@@ -160,7 +160,7 @@ describe("parseSearchParams", () => {
     it("leaves attributes untouched when no alias matches", () => {
       expect(
         parseSearchParams("?filter[unknown]=x", {
-          aliases: { userName: "name" },
+          urlAliases: { userName: "name" },
         }),
       ).toEqual({ filters: [{ attribute: "unknown", value: ["x"] }] });
     });
@@ -168,7 +168,7 @@ describe("parseSearchParams", () => {
     it("first-wins on alias collisions (multiple frontends → same backend)", () => {
       expect(
         parseSearchParams("?filter[name]=John", {
-          aliases: { userName: "name", fullName: "name" },
+          urlAliases: { userName: "name", fullName: "name" },
         }),
       ).toEqual({ filters: [{ attribute: "userName", value: ["John"] }] });
     });
@@ -243,13 +243,13 @@ describe("parseSearchParams", () => {
   });
 
   describe("policy is alias-aware (matches both frontend and backend names)", () => {
-    const aliases = { userName: "name", adminFlag: "is_admin" };
+    const urlAliases = { userName: "name", adminFlag: "is_admin" };
 
     it("DX: allowed.filters with FRONTEND name hydrates a URL with backend name", () => {
       // Dev writes the name they think in (frontend), URL has the wire name.
       expect(
         parseSearchParams("?filter[name]=John", {
-          aliases,
+          urlAliases,
           allowed: { filters: ["userName"] },
         }),
       ).toEqual({ filters: [{ attribute: "userName", value: ["John"] }] });
@@ -258,7 +258,7 @@ describe("parseSearchParams", () => {
     it("DX: allowed.filters with BACKEND name also works (existing behaviour)", () => {
       expect(
         parseSearchParams("?filter[name]=John", {
-          aliases,
+          urlAliases,
           allowed: { filters: ["name"] },
         }),
       ).toEqual({ filters: [{ attribute: "userName", value: ["John"] }] });
@@ -268,7 +268,7 @@ describe("parseSearchParams", () => {
       // Attacker tries to bypass `is_admin` denylist by using the alias key.
       expect(
         parseSearchParams("?filter[adminFlag]=true", {
-          aliases,
+          urlAliases,
           excludeKeys: { filters: ["is_admin"] },
         }),
       ).toEqual({});
@@ -277,7 +277,7 @@ describe("parseSearchParams", () => {
     it("security: excludeKeys.filters with frontend name still blocks backend URL form", () => {
       expect(
         parseSearchParams("?filter[is_admin]=true", {
-          aliases,
+          urlAliases,
           excludeKeys: { filters: ["adminFlag"] },
         }),
       ).toEqual({});
@@ -286,14 +286,14 @@ describe("parseSearchParams", () => {
     it("sorts get the same dual-name treatment", () => {
       expect(
         parseSearchParams("?sort=-name", {
-          aliases,
+          urlAliases,
           allowed: { sorts: ["userName"] },
         }),
       ).toEqual({ sorts: [{ attribute: "userName", direction: "desc" }] });
 
       expect(
         parseSearchParams("?sort=adminFlag", {
-          aliases,
+          urlAliases,
           excludeKeys: { sorts: ["is_admin"] },
         }),
       ).toEqual({});
@@ -354,7 +354,7 @@ describe("parseSearchParams", () => {
     it("matches the raw backend name BEFORE reverse alias", () => {
       expect(
         parseSearchParams("?filter[is_admin]=true", {
-          aliases: { isAdmin: "is_admin" },
+          urlAliases: { isAdmin: "is_admin" },
           excludeKeys: { filters: ["is_admin"] },
         }),
       ).toEqual({});

--- a/tests/Units/searchParamsAdapter.dom.test.ts
+++ b/tests/Units/searchParamsAdapter.dom.test.ts
@@ -7,24 +7,16 @@ describe("createSearchParamsAdapter (browser env)", () => {
     window.history.replaceState(null, "", "/");
   });
 
-  it("reads from window.location.search when no source is given", () => {
-    window.history.replaceState(null, "", "/?filter[status]=active&sort=-name");
+  it("falls back to window.location.search on every read() when no source is given", () => {
     const adapter = createSearchParamsAdapter();
 
+    window.history.replaceState(null, "", "/?filter[status]=active&sort=-name");
     expect(adapter.read()).toEqual({
       filters: [{ attribute: "status", value: ["active"] }],
       sorts: [{ attribute: "name", direction: "desc" }],
     });
-  });
 
-  it("re-reads window.location.search on every read() call", () => {
-    const adapter = createSearchParamsAdapter();
-
-    window.history.replaceState(null, "", "/?filter[status]=active");
-    expect(adapter.read()).toEqual({
-      filters: [{ attribute: "status", value: ["active"] }],
-    });
-
+    // Re-read picks up the new URL — proving the default source is re-evaluated.
     window.history.replaceState(null, "", "/?filter[status]=archived");
     expect(adapter.read()).toEqual({
       filters: [{ attribute: "status", value: ["archived"] }],

--- a/tests/Units/searchParamsAdapter.dom.test.ts
+++ b/tests/Units/searchParamsAdapter.dom.test.ts
@@ -67,14 +67,20 @@ describe("createSearchParamsAdapter (browser env)", () => {
     expect(window.location.pathname).toBe("/users");
   });
 
-  it("sync:'push' uses history.pushState (adds a back-button entry)", () => {
+  it("sync:'push' uses history.pushState for mutations but replaceState on first call", () => {
     const initialLength = window.history.length;
     const adapter = createSearchParamsAdapter({ sync: "push" });
 
+    // First call is the mount-time normalisation — always replaceState,
+    // even with sync:"push", so we don't add a phantom history entry.
     adapter.write?.(fullState({ filters: [{ attribute: "x", value: ["1"] }] }));
-
-    expect(window.history.length).toBe(initialLength + 1);
+    expect(window.history.length).toBe(initialLength);
     expect(window.location.search).toContain("filter[x]=1");
+
+    // Second call is a real mutation → pushState adds an entry.
+    adapter.write?.(fullState({ filters: [{ attribute: "x", value: ["2"] }] }));
+    expect(window.history.length).toBe(initialLength + 1);
+    expect(window.location.search).toContain("filter[x]=2");
   });
 
   it("subsequent writes overwrite the previously managed keys", () => {

--- a/tests/Units/searchParamsAdapter.dom.test.ts
+++ b/tests/Units/searchParamsAdapter.dom.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+import { createSearchParamsAdapter } from "@/adapters/searchParams";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("createSearchParamsAdapter (browser env)", () => {
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("reads from window.location.search when no source is given", () => {
+    window.history.replaceState(null, "", "/?filter[status]=active&sort=-name");
+    const adapter = createSearchParamsAdapter();
+
+    expect(adapter.read()).toEqual({
+      filters: [{ attribute: "status", value: ["active"] }],
+      sorts: [{ attribute: "name", direction: "desc" }],
+    });
+  });
+
+  it("re-reads window.location.search on every read() call", () => {
+    const adapter = createSearchParamsAdapter();
+
+    window.history.replaceState(null, "", "/?filter[status]=active");
+    expect(adapter.read()).toEqual({
+      filters: [{ attribute: "status", value: ["active"] }],
+    });
+
+    window.history.replaceState(null, "", "/?filter[status]=archived");
+    expect(adapter.read()).toEqual({
+      filters: [{ attribute: "status", value: ["archived"] }],
+    });
+  });
+});

--- a/tests/Units/searchParamsAdapter.dom.test.ts
+++ b/tests/Units/searchParamsAdapter.dom.test.ts
@@ -98,6 +98,18 @@ describe("createSearchParamsAdapter (browser env)", () => {
     ).toEqual(["archived"]);
   });
 
+  it("overwrites page/limit on subsequent writes instead of appending", () => {
+    const adapter = createSearchParamsAdapter({ sync: true });
+
+    adapter.write?.(fullState({ pagination: { page: 1, limit: 20 } }));
+    adapter.write?.(fullState({ pagination: { page: 2, limit: 20 } }));
+    adapter.write?.(fullState({ pagination: { page: 3, limit: 50 } }));
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.getAll("page")).toEqual(["3"]);
+    expect(params.getAll("limit")).toEqual(["50"]);
+  });
+
   it("clears managed keys when state has nothing to write", () => {
     window.history.replaceState(
       null,

--- a/tests/Units/searchParamsAdapter.dom.test.ts
+++ b/tests/Units/searchParamsAdapter.dom.test.ts
@@ -3,9 +3,7 @@ import { createSearchParamsAdapter } from "@/adapters/searchParams";
 import { type GlobalState } from "@/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const fullState = <
-  A extends Record<string, string> | undefined = undefined,
->(
+const fullState = <A extends Record<string, string> | undefined = undefined>(
   overrides: Partial<GlobalState<A>>,
 ): GlobalState<A> => ({
   aliases: {} as A,
@@ -51,7 +49,7 @@ describe("createSearchParamsAdapter (browser env)", () => {
   it("sync:true writes to history.replaceState and preserves unmanaged params", () => {
     window.history.replaceState(null, "", "/users?utm_source=newsletter");
     const adapter = createSearchParamsAdapter({
-      allowedParams: ["locale"],
+      allowed: { params: ["locale"] },
       sync: true,
     });
 
@@ -73,9 +71,7 @@ describe("createSearchParamsAdapter (browser env)", () => {
     const initialLength = window.history.length;
     const adapter = createSearchParamsAdapter({ sync: "push" });
 
-    adapter.write?.(
-      fullState({ filters: [{ attribute: "x", value: ["1"] }] }),
-    );
+    adapter.write?.(fullState({ filters: [{ attribute: "x", value: ["1"] }] }));
 
     expect(window.history.length).toBe(initialLength + 1);
     expect(window.location.search).toContain("filter[x]=1");

--- a/tests/Units/searchParamsAdapter.dom.test.ts
+++ b/tests/Units/searchParamsAdapter.dom.test.ts
@@ -1,6 +1,32 @@
 // @vitest-environment happy-dom
 import { createSearchParamsAdapter } from "@/adapters/searchParams";
-import { afterEach, describe, expect, it } from "vitest";
+import { type GlobalState } from "@/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fullState = <
+  A extends Record<string, string> | undefined = undefined,
+>(
+  overrides: Partial<GlobalState<A>>,
+): GlobalState<A> => ({
+  aliases: {} as A,
+  filters: [],
+  includes: [],
+  sorts: [],
+  fields: [],
+  params: {},
+  pruneConflictingFilters: {},
+  delimiters: {
+    global: ",",
+    fields: null,
+    filters: null,
+    sorts: null,
+    includes: null,
+    params: null,
+  },
+  useQuestionMark: true,
+  pagination: {},
+  ...overrides,
+});
 
 describe("createSearchParamsAdapter (browser env)", () => {
   afterEach(() => {
@@ -16,10 +42,91 @@ describe("createSearchParamsAdapter (browser env)", () => {
       sorts: [{ attribute: "name", direction: "desc" }],
     });
 
-    // Re-read picks up the new URL — proving the default source is re-evaluated.
     window.history.replaceState(null, "", "/?filter[status]=archived");
     expect(adapter.read()).toEqual({
       filters: [{ attribute: "status", value: ["archived"] }],
     });
+  });
+
+  it("sync:true writes to history.replaceState and preserves unmanaged params", () => {
+    window.history.replaceState(null, "", "/users?utm_source=newsletter");
+    const adapter = createSearchParamsAdapter({
+      allowedParams: ["locale"],
+      sync: true,
+    });
+
+    adapter.write?.(
+      fullState({
+        filters: [{ attribute: "status", value: ["active"] }],
+        params: { locale: ["es"] },
+      }),
+    );
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("filter[status]")).toBe("active");
+    expect(params.get("locale")).toBe("es");
+    expect(params.get("utm_source")).toBe("newsletter");
+    expect(window.location.pathname).toBe("/users");
+  });
+
+  it("sync:'push' uses history.pushState (adds a back-button entry)", () => {
+    const initialLength = window.history.length;
+    const adapter = createSearchParamsAdapter({ sync: "push" });
+
+    adapter.write?.(
+      fullState({ filters: [{ attribute: "x", value: ["1"] }] }),
+    );
+
+    expect(window.history.length).toBe(initialLength + 1);
+    expect(window.location.search).toContain("filter[x]=1");
+  });
+
+  it("subsequent writes overwrite the previously managed keys", () => {
+    const adapter = createSearchParamsAdapter({ sync: true });
+
+    adapter.write?.(
+      fullState({ filters: [{ attribute: "status", value: ["active"] }] }),
+    );
+    adapter.write?.(
+      fullState({ filters: [{ attribute: "status", value: ["archived"] }] }),
+    );
+
+    expect(
+      new URLSearchParams(window.location.search).getAll("filter[status]"),
+    ).toEqual(["archived"]);
+  });
+
+  it("clears managed keys when state has nothing to write", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/?filter[status]=active&utm_source=x",
+    );
+    const adapter = createSearchParamsAdapter({ sync: true });
+
+    adapter.write?.(fullState({}));
+
+    expect(window.location.search).toBe("?utm_source=x");
+  });
+
+  it("strips the search entirely when nothing managed or unmanaged remains", () => {
+    window.history.replaceState(null, "", "/?filter[x]=1");
+    const adapter = createSearchParamsAdapter({ sync: true });
+
+    adapter.write?.(fullState({}));
+
+    expect(window.location.search).toBe("");
+  });
+
+  it("custom sync function receives the serialised search string", () => {
+    const sync = vi.fn();
+    const adapter = createSearchParamsAdapter({ sync });
+
+    adapter.write?.(
+      fullState({ filters: [{ attribute: "status", value: ["active"] }] }),
+    );
+
+    expect(sync).toHaveBeenCalledWith("filter[status]=active");
+    expect(window.location.search).toBe(""); // custom callback bypasses default writer
   });
 });

--- a/tests/Units/searchParamsAdapter.test.ts
+++ b/tests/Units/searchParamsAdapter.test.ts
@@ -1,0 +1,39 @@
+import { createSearchParamsAdapter } from "@/adapters/searchParams";
+import { describe, expect, it, vi } from "vitest";
+
+describe("createSearchParamsAdapter", () => {
+  it("does not call source until read() is invoked", () => {
+    const source = vi.fn(() => "?filter[status]=active");
+    const adapter = createSearchParamsAdapter({ source });
+
+    expect(source).not.toHaveBeenCalled();
+
+    adapter.read();
+
+    expect(source).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the injected source over window.location.search", () => {
+    const adapter = createSearchParamsAdapter({
+      source: () => "?filter[status]=active&include=user",
+    });
+
+    expect(adapter.read()).toEqual({
+      filters: [{ attribute: "status", value: ["active"] }],
+      includes: ["user"],
+    });
+  });
+
+  it("propagates custom keys and allowedParams to the parser", () => {
+    const adapter = createSearchParamsAdapter({
+      source: () => "?filt[status]=active&locale=es&unwanted=1",
+      keys: { filter: "filt" },
+      allowedParams: ["locale"],
+    });
+
+    expect(adapter.read()).toEqual({
+      filters: [{ attribute: "status", value: ["active"] }],
+      params: { locale: ["es"] },
+    });
+  });
+});

--- a/tests/Units/searchParamsAdapter.test.ts
+++ b/tests/Units/searchParamsAdapter.test.ts
@@ -11,11 +11,11 @@ describe("createSearchParamsAdapter", () => {
     expect(source).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards source, keys, and allowedParams to the parser", () => {
+  it("forwards source, keys, and allowed.params to the parser", () => {
     const adapter = createSearchParamsAdapter({
       source: () => "?filt[status]=active&locale=es&unwanted=1",
       keys: { filter: "filt" },
-      allowedParams: ["locale"],
+      allowed: { params: ["locale"] },
     });
 
     expect(adapter.read()).toEqual({
@@ -39,7 +39,7 @@ describe("createSearchParamsAdapter", () => {
     const sync = vi.fn();
     const adapter = createSearchParamsAdapter<Record<string, string>>({
       keys: { filter: "filt" },
-      allowedParams: ["locale"],
+      allowed: { params: ["locale"] },
       sync,
     });
 

--- a/tests/Units/searchParamsAdapter.test.ts
+++ b/tests/Units/searchParamsAdapter.test.ts
@@ -36,4 +36,9 @@ describe("createSearchParamsAdapter", () => {
       params: { locale: ["es"] },
     });
   });
+
+  it("returns {} when no source is given and window is unavailable (SSR/node env)", () => {
+    const adapter = createSearchParamsAdapter();
+    expect(adapter.read()).toEqual({});
+  });
 });

--- a/tests/Units/searchParamsAdapter.test.ts
+++ b/tests/Units/searchParamsAdapter.test.ts
@@ -27,4 +27,71 @@ describe("createSearchParamsAdapter", () => {
   it("returns {} when no source is given and window is unavailable (SSR/node)", () => {
     expect(createSearchParamsAdapter().read()).toEqual({});
   });
+
+  it("does not expose write() unless sync is configured", () => {
+    expect(createSearchParamsAdapter().write).toBeUndefined();
+    expect(
+      createSearchParamsAdapter({ source: () => "" }).write,
+    ).toBeUndefined();
+  });
+
+  it("invokes a custom sync callback with the serialised search string", () => {
+    const sync = vi.fn();
+    const adapter = createSearchParamsAdapter<Record<string, string>>({
+      keys: { filter: "filt" },
+      allowedParams: ["locale"],
+      sync,
+    });
+
+    expect(adapter.write).toBeDefined();
+    adapter.write?.({
+      aliases: {},
+      filters: [{ attribute: "status", value: ["active"] }],
+      includes: [],
+      sorts: [],
+      fields: [],
+      params: { locale: ["es"], dropped: ["x"] },
+      pruneConflictingFilters: {},
+      delimiters: {
+        global: ",",
+        fields: null,
+        filters: null,
+        sorts: null,
+        includes: null,
+        params: null,
+      },
+      useQuestionMark: true,
+      pagination: {},
+    });
+
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(sync).toHaveBeenCalledWith("filt[status]=active&locale=es");
+  });
+
+  it("default writer is a no-op when window is unavailable (SSR/node)", () => {
+    const adapter = createSearchParamsAdapter<Record<string, string>>({
+      sync: true,
+    });
+    expect(() =>
+      adapter.write?.({
+        aliases: {},
+        filters: [{ attribute: "status", value: ["active"] }],
+        includes: [],
+        sorts: [],
+        fields: [],
+        params: {},
+        pruneConflictingFilters: {},
+        delimiters: {
+          global: ",",
+          fields: null,
+          filters: null,
+          sorts: null,
+          includes: null,
+          params: null,
+        },
+        useQuestionMark: true,
+        pagination: {},
+      }),
+    ).not.toThrow();
+  });
 });

--- a/tests/Units/searchParamsAdapter.test.ts
+++ b/tests/Units/searchParamsAdapter.test.ts
@@ -7,24 +7,11 @@ describe("createSearchParamsAdapter", () => {
     const adapter = createSearchParamsAdapter({ source });
 
     expect(source).not.toHaveBeenCalled();
-
     adapter.read();
-
     expect(source).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the injected source over window.location.search", () => {
-    const adapter = createSearchParamsAdapter({
-      source: () => "?filter[status]=active&include=user",
-    });
-
-    expect(adapter.read()).toEqual({
-      filters: [{ attribute: "status", value: ["active"] }],
-      includes: ["user"],
-    });
-  });
-
-  it("propagates custom keys and allowedParams to the parser", () => {
+  it("forwards source, keys, and allowedParams to the parser", () => {
     const adapter = createSearchParamsAdapter({
       source: () => "?filt[status]=active&locale=es&unwanted=1",
       keys: { filter: "filt" },
@@ -37,8 +24,7 @@ describe("createSearchParamsAdapter", () => {
     });
   });
 
-  it("returns {} when no source is given and window is unavailable (SSR/node env)", () => {
-    const adapter = createSearchParamsAdapter();
-    expect(adapter.read()).toEqual({});
+  it("returns {} when no source is given and window is unavailable (SSR/node)", () => {
+    expect(createSearchParamsAdapter().read()).toEqual({});
   });
 });

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -62,7 +62,9 @@ describe("serializeSearchParams", () => {
           includes: ["user"],
           fields: ["user.id"],
         },
-        { keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" } },
+        {
+          keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" },
+        },
       ),
     ).toBe("filt[status]=active&fld[user]=id&srt=-name&inc=user");
   });
@@ -71,9 +73,110 @@ describe("serializeSearchParams", () => {
     expect(
       serializeSearchParams(
         { params: { locale: ["es"], tenant: ["acme"], secret: ["leak"] } },
-        { allowedParams: ["locale", "tenant"] },
+        { allowed: { params: ["locale", "tenant"] } },
       ),
     ).toBe("locale=es&tenant=acme");
+  });
+
+  describe("writer respects allowed + excludeKeys (symmetric with reader)", () => {
+    it("drops filters not in allowed.filters", () => {
+      expect(
+        serializeSearchParams(
+          {
+            filters: [
+              { attribute: "status", value: ["active"] },
+              { attribute: "is_admin", value: ["true"] },
+            ],
+          },
+          { allowed: { filters: ["status"] } },
+        ),
+      ).toBe("filter[status]=active");
+    });
+
+    it("drops sorts/includes/fields not in their bucket allowlist", () => {
+      expect(
+        serializeSearchParams(
+          {
+            sorts: [
+              { attribute: "name", direction: "asc" },
+              { attribute: "secret", direction: "asc" },
+            ],
+            includes: ["user", "internal_log"],
+            fields: ["id", "password"],
+          },
+          {
+            allowed: {
+              sorts: ["name"],
+              includes: ["user"],
+              fields: ["id"],
+            },
+          },
+        ),
+      ).toBe("fields=id&sort=name&include=user");
+    });
+
+    it("excludeKeys drops on write across all buckets", () => {
+      expect(
+        serializeSearchParams(
+          {
+            filters: [
+              { attribute: "name", value: ["x"] },
+              { attribute: "is_admin", value: ["true"] },
+            ],
+            sorts: [
+              { attribute: "name", direction: "asc" },
+              { attribute: "secret_score", direction: "desc" },
+            ],
+            includes: ["user", "internal_log"],
+            params: { locale: ["es"], debug: ["1"] },
+          },
+          {
+            allowed: { params: ["locale", "debug"] },
+            excludeKeys: {
+              filters: ["is_admin"],
+              sorts: ["secret_score"],
+              includes: ["internal_log"],
+              params: ["debug"],
+            },
+          },
+        ),
+      ).toBe("filter[name]=x&sort=name&include=user&locale=es");
+    });
+
+    it("excludeKeys wins over allowed when both are set", () => {
+      expect(
+        serializeSearchParams(
+          {
+            filters: [
+              { attribute: "name", value: ["x"] },
+              { attribute: "status", value: ["y"] },
+            ],
+          },
+          {
+            allowed: { filters: ["name", "status"] },
+            excludeKeys: { filters: ["status"] },
+          },
+        ),
+      ).toBe("filter[name]=x");
+    });
+
+    it("allowed.fields filters bracketed (entity.prop) fields too", () => {
+      expect(
+        serializeSearchParams(
+          { fields: ["user.id", "user.password", "admin.role"] },
+          { allowed: { fields: ["user.id", "admin.role"] } },
+        ),
+      ).toBe("fields[user]=id&fields[admin]=role");
+    });
+
+    it("applies excludeKeys to fields by short prop or entity.prop", () => {
+      expect(
+        serializeSearchParams(
+          { fields: ["id", "user.password", "user.name", "admin.password"] },
+          { excludeKeys: { fields: ["password"] } },
+        ),
+      ).toBe("fields=id&fields[user]=name");
+    });
   });
 
   it("round-trips with parseSearchParams for the canonical case", async () => {
@@ -86,11 +189,11 @@ describe("serializeSearchParams", () => {
       params: { locale: ["es"] },
     };
     const serialized = serializeSearchParams(state, {
-      allowedParams: ["locale"],
+      allowed: { params: ["locale"] },
     });
-    expect(parseSearchParams(serialized, { allowedParams: ["locale"] })).toEqual(
-      state,
-    );
+    expect(
+      parseSearchParams(serialized, { allowed: { params: ["locale"] } }),
+    ).toEqual(state);
   });
 
   describe("aliases (forward map)", () => {

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -263,6 +263,30 @@ describe("serializeSearchParams", () => {
       ).toBe("filter[name]=John");
     });
 
+    it("policy is alias-aware on write: allowed.filters with FRONTEND name passes", () => {
+      expect(
+        serializeSearchParams(
+          { filters: [{ attribute: "userName", value: ["John"] }] },
+          {
+            aliases: { userName: "name" },
+            allowed: { filters: ["userName"] },
+          },
+        ),
+      ).toBe("filter[name]=John");
+    });
+
+    it("policy is alias-aware on write: excludeKeys with BACKEND name drops a state entry that aliases to it", () => {
+      expect(
+        serializeSearchParams(
+          { filters: [{ attribute: "adminFlag", value: ["true"] }] },
+          {
+            aliases: { adminFlag: "is_admin" },
+            excludeKeys: { filters: ["is_admin"] },
+          },
+        ),
+      ).toBe("");
+    });
+
     it("round-trips through parseSearchParams with aliases on both ends", async () => {
       const { parseSearchParams } = await import("@/utils/parseSearchParams");
       const aliases = { userName: "name", createdAt: "created_at" };

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -336,6 +336,39 @@ describe("serializeSearchParams", () => {
       );
     });
 
+    it("urlOmit with '*' wildcard drops every entry in that bucket", () => {
+      expect(
+        serializeSearchParams(
+          {
+            filters: [{ attribute: "status", value: ["active"] }],
+            includes: ["author", "tags"],
+            fields: ["id", "user.name", "user.email"],
+          },
+          { urlOmit: { fields: ["*"], includes: ["*"] } },
+        ),
+      ).toBe("filter[status]=active");
+    });
+
+    it("urlOmit '*' coexists with named entries in other buckets", () => {
+      expect(
+        serializeSearchParams(
+          {
+            filters: [
+              { attribute: "status", value: ["active"] },
+              { attribute: "is_admin", value: ["true"] },
+            ],
+            includes: ["user", "logs"],
+          },
+          {
+            urlOmit: {
+              filters: ["is_admin"], // specific
+              includes: ["*"],       // wildcard
+            },
+          },
+        ),
+      ).toBe("filter[status]=active");
+    });
+
     it("urlOmit is alias-aware on filters and sorts", () => {
       expect(
         serializeSearchParams(
@@ -354,7 +387,7 @@ describe("serializeSearchParams", () => {
             urlOmit: {
               filters: ["documento"], // listed by WIRE name → state "dni" also dropped
               sorts: ["dni"], // listed by STATE name → wire "dni" also dropped
-            },
+            }
           },
         ),
       ).toBe("filter[name]=x&sort=name");

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -179,6 +179,34 @@ describe("serializeSearchParams", () => {
     });
   });
 
+  describe("safe encoding for special characters in values", () => {
+    it("round-trips a value containing a literal percent sign", async () => {
+      const { parseSearchParams } = await import("@/utils/parseSearchParams");
+      const state = {
+        filters: [{ attribute: "name", value: ["50%25discount"] }],
+      };
+      const url = serializeSearchParams(state);
+      expect(parseSearchParams(url)).toEqual(state);
+    });
+
+    it("round-trips values with =, &, # and spaces", async () => {
+      const { parseSearchParams } = await import("@/utils/parseSearchParams");
+      const state = {
+        filters: [{ attribute: "q", value: ["a=b & c#1", "hello world"] }],
+      };
+      const url = serializeSearchParams(state);
+      expect(parseSearchParams(url)).toEqual(state);
+    });
+
+    it("keeps brackets readable in the output URL", () => {
+      expect(
+        serializeSearchParams({
+          filters: [{ attribute: "status", value: ["active"] }],
+        }),
+      ).toBe("filter[status]=active");
+    });
+  });
+
   it("round-trips with parseSearchParams for the canonical case", async () => {
     const { parseSearchParams } = await import("@/utils/parseSearchParams");
     const state: Partial<GlobalState> = {

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -242,19 +242,19 @@ describe("serializeSearchParams", () => {
   });
 
   describe("aliases (forward map)", () => {
-    it("rewrites filter and sort attributes from frontend → backend via options", () => {
+    it("rewrites filter and sort attributes from frontend → backend via urlAliases", () => {
       expect(
         serializeSearchParams(
           {
             filters: [{ attribute: "userName", value: ["John"] }],
             sorts: [{ attribute: "createdAt", direction: "desc" }],
           },
-          { aliases: { userName: "name", createdAt: "created_at" } },
+          { urlAliases: { userName: "name", createdAt: "created_at" } },
         ),
       ).toBe("filter[name]=John&sort=-created_at");
     });
 
-    it("falls back to state.aliases when options.aliases is absent", () => {
+    it("falls back to state.aliases when options.urlAliases is absent", () => {
       expect(
         serializeSearchParams<{ userName: "name" }>({
           aliases: { userName: "name" },
@@ -268,7 +268,7 @@ describe("serializeSearchParams", () => {
         serializeSearchParams(
           { filters: [{ attribute: "userName", value: ["John"] }] },
           {
-            aliases: { userName: "name" },
+            urlAliases: { userName: "name" },
             allowed: { filters: ["userName"] },
           },
         ),
@@ -280,22 +280,22 @@ describe("serializeSearchParams", () => {
         serializeSearchParams(
           { filters: [{ attribute: "adminFlag", value: ["true"] }] },
           {
-            aliases: { adminFlag: "is_admin" },
+            urlAliases: { adminFlag: "is_admin" },
             excludeKeys: { filters: ["is_admin"] },
           },
         ),
       ).toBe("");
     });
 
-    it("round-trips through parseSearchParams with aliases on both ends", async () => {
+    it("round-trips through parseSearchParams with the same urlAliases on both ends", async () => {
       const { parseSearchParams } = await import("@/utils/parseSearchParams");
-      const aliases = { userName: "name", createdAt: "created_at" };
+      const urlAliases = { userName: "name", createdAt: "created_at" };
       const state = {
         filters: [{ attribute: "userName", value: ["John"] }],
         sorts: [{ attribute: "createdAt", direction: "desc" as const }],
       };
-      const url = serializeSearchParams(state, { aliases });
-      expect(parseSearchParams(url, { aliases })).toEqual(state);
+      const url = serializeSearchParams(state, { urlAliases });
+      expect(parseSearchParams(url, { urlAliases })).toEqual(state);
     });
   });
 });

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -1,0 +1,129 @@
+import { type GlobalState } from "@/types";
+import { serializeSearchParams } from "@/utils/serializeSearchParams";
+import { describe, expect, it } from "vitest";
+
+describe("serializeSearchParams", () => {
+  it("returns an empty string for empty state", () => {
+    expect(serializeSearchParams({})).toBe("");
+  });
+
+  it.each<[string, Partial<GlobalState>, string]>([
+    [
+      "filters with single and multi-value",
+      {
+        filters: [
+          { attribute: "status", value: ["active", "pending"] },
+          { attribute: "name", value: ["John"] },
+        ],
+      },
+      "filter[status]=active,pending&filter[name]=John",
+    ],
+    [
+      "filters with operator prefixes",
+      {
+        filters: [
+          { attribute: "age", value: ["18"], operator: ">=" },
+          { attribute: "score", value: ["0"], operator: "<>" },
+        ],
+      },
+      "filter[age]=>=18&filter[score]=<>0",
+    ],
+    [
+      "filter with equals operator omits the prefix",
+      { filters: [{ attribute: "x", value: ["1"], operator: "=" }] },
+      "filter[x]=1",
+    ],
+    [
+      "sort with mixed directions",
+      {
+        sorts: [
+          { attribute: "created_at", direction: "desc" },
+          { attribute: "name", direction: "asc" },
+        ],
+      },
+      "sort=-created_at,name",
+    ],
+    ["include into csv", { includes: ["user", "team"] }, "include=user,team"],
+    [
+      "bare and dotted fields collapsed to bracketed groups",
+      { fields: ["id", "user.name", "user.email"] },
+      "fields=id&fields[user]=name,email",
+    ],
+  ])("serialises %s", (_label, state, expected) => {
+    expect(serializeSearchParams(state)).toBe(expected);
+  });
+
+  it("honours custom URL keys", () => {
+    expect(
+      serializeSearchParams(
+        {
+          filters: [{ attribute: "status", value: ["active"] }],
+          sorts: [{ attribute: "name", direction: "desc" }],
+          includes: ["user"],
+          fields: ["user.id"],
+        },
+        { keys: { filter: "filt", sort: "srt", include: "inc", fields: "fld" } },
+      ),
+    ).toBe("filt[status]=active&fld[user]=id&srt=-name&inc=user");
+  });
+
+  it("writes only allowlisted params; drops the rest", () => {
+    expect(
+      serializeSearchParams(
+        { params: { locale: ["es"], tenant: ["acme"], secret: ["leak"] } },
+        { allowedParams: ["locale", "tenant"] },
+      ),
+    ).toBe("locale=es&tenant=acme");
+  });
+
+  it("round-trips with parseSearchParams for the canonical case", async () => {
+    const { parseSearchParams } = await import("@/utils/parseSearchParams");
+    const state: Partial<GlobalState> = {
+      filters: [{ attribute: "status", value: ["active"] }],
+      sorts: [{ attribute: "name", direction: "desc" }],
+      includes: ["user"],
+      fields: ["user.id", "user.email"],
+      params: { locale: ["es"] },
+    };
+    const serialized = serializeSearchParams(state, {
+      allowedParams: ["locale"],
+    });
+    expect(parseSearchParams(serialized, { allowedParams: ["locale"] })).toEqual(
+      state,
+    );
+  });
+
+  describe("aliases (forward map)", () => {
+    it("rewrites filter and sort attributes from frontend → backend via options", () => {
+      expect(
+        serializeSearchParams(
+          {
+            filters: [{ attribute: "userName", value: ["John"] }],
+            sorts: [{ attribute: "createdAt", direction: "desc" }],
+          },
+          { aliases: { userName: "name", createdAt: "created_at" } },
+        ),
+      ).toBe("filter[name]=John&sort=-created_at");
+    });
+
+    it("falls back to state.aliases when options.aliases is absent", () => {
+      expect(
+        serializeSearchParams<{ userName: "name" }>({
+          aliases: { userName: "name" },
+          filters: [{ attribute: "userName", value: ["John"] }],
+        }),
+      ).toBe("filter[name]=John");
+    });
+
+    it("round-trips through parseSearchParams with aliases on both ends", async () => {
+      const { parseSearchParams } = await import("@/utils/parseSearchParams");
+      const aliases = { userName: "name", createdAt: "created_at" };
+      const state = {
+        filters: [{ attribute: "userName", value: ["John"] }],
+        sorts: [{ attribute: "createdAt", direction: "desc" as const }],
+      };
+      const url = serializeSearchParams(state, { aliases });
+      expect(parseSearchParams(url, { aliases })).toEqual(state);
+    });
+  });
+});

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -179,6 +179,23 @@ describe("serializeSearchParams", () => {
     });
   });
 
+  it("accepts an externally pre-compiled policy as the 3rd argument", async () => {
+    const { compilePolicy } = await import("@/utils/searchParamsPolicy");
+    const policy = compilePolicy({ allowed: { filters: ["status"] } });
+    expect(
+      serializeSearchParams(
+        {
+          filters: [
+            { attribute: "status", value: ["active"] },
+            { attribute: "is_admin", value: ["true"] },
+          ],
+        },
+        undefined,
+        policy,
+      ),
+    ).toBe("filter[status]=active");
+  });
+
   describe("safe encoding for special characters in values", () => {
     it("round-trips a value containing a literal percent sign", async () => {
       const { parseSearchParams } = await import("@/utils/parseSearchParams");

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -287,6 +287,47 @@ describe("serializeSearchParams", () => {
       ).toBe("");
     });
 
+    it("urlOmit hides entries from the URL but keeps them in state output of .build()", () => {
+      // Writer skips listed names; the items are still in `state` (the
+      // caller's responsibility — we verify the URL output only here).
+      expect(
+        serializeSearchParams({
+          filters: [{ attribute: "status", value: ["active"] }],
+          includes: ["organization", "permissions", "author"],
+          fields: ["id", "user.email", "internal_token"],
+        }, {
+          urlOmit: {
+            includes: ["organization", "permissions"],
+            fields:   ["internal_token"],
+          },
+        }),
+      ).toBe("filter[status]=active&fields=id&fields[user]=email&include=author");
+    });
+
+    it("urlOmit is alias-aware on filters and sorts", () => {
+      expect(
+        serializeSearchParams(
+          {
+            filters: [
+              { attribute: "dni",  value: ["123"] },
+              { attribute: "name", value: ["x"] },
+            ],
+            sorts: [
+              { attribute: "dni",  direction: "asc" },
+              { attribute: "name", direction: "asc" },
+            ],
+          },
+          {
+            urlAliases: { dni: "documento" },
+            urlOmit: {
+              filters: ["documento"], // listed by WIRE name → state "dni" also dropped
+              sorts:   ["dni"],       // listed by STATE name → wire "dni" also dropped
+            },
+          },
+        ),
+      ).toBe("filter[name]=x&sort=name");
+    });
+
     it("round-trips through parseSearchParams with the same urlAliases on both ends", async () => {
       const { parseSearchParams } = await import("@/utils/parseSearchParams");
       const urlAliases = { userName: "name", createdAt: "created_at" };

--- a/tests/Units/serializeSearchParams.test.ts
+++ b/tests/Units/serializeSearchParams.test.ts
@@ -179,6 +179,33 @@ describe("serializeSearchParams", () => {
     });
   });
 
+  describe("pagination", () => {
+    it("emits page and limit when present in state", () => {
+      expect(
+        serializeSearchParams({ pagination: { page: 3, limit: 20 } }),
+      ).toBe("page=3&limit=20");
+    });
+
+    it("emits page only when limit is undefined", () => {
+      expect(serializeSearchParams({ pagination: { page: 5 } })).toBe("page=5");
+    });
+
+    it("emits nothing when pagination is absent or empty", () => {
+      expect(serializeSearchParams({})).toBe("");
+      expect(serializeSearchParams({ pagination: {} })).toBe("");
+    });
+
+    it("round-trips pagination through parseSearchParams", async () => {
+      const { parseSearchParams } = await import("@/utils/parseSearchParams");
+      const state = {
+        filters: [{ attribute: "status", value: ["active"] }],
+        pagination: { page: 7, limit: 50 },
+      };
+      const url = serializeSearchParams(state);
+      expect(parseSearchParams(url)).toEqual(state);
+    });
+  });
+
   it("accepts an externally pre-compiled policy as the 3rd argument", async () => {
     const { compilePolicy } = await import("@/utils/searchParamsPolicy");
     const policy = compilePolicy({ allowed: { filters: ["status"] } });
@@ -291,17 +318,22 @@ describe("serializeSearchParams", () => {
       // Writer skips listed names; the items are still in `state` (the
       // caller's responsibility — we verify the URL output only here).
       expect(
-        serializeSearchParams({
-          filters: [{ attribute: "status", value: ["active"] }],
-          includes: ["organization", "permissions", "author"],
-          fields: ["id", "user.email", "internal_token"],
-        }, {
-          urlOmit: {
-            includes: ["organization", "permissions"],
-            fields:   ["internal_token"],
+        serializeSearchParams(
+          {
+            filters: [{ attribute: "status", value: ["active"] }],
+            includes: ["organization", "permissions", "author"],
+            fields: ["id", "user.email", "internal_token"],
           },
-        }),
-      ).toBe("filter[status]=active&fields=id&fields[user]=email&include=author");
+          {
+            urlOmit: {
+              includes: ["organization", "permissions"],
+              fields: ["internal_token"],
+            },
+          },
+        ),
+      ).toBe(
+        "filter[status]=active&fields=id&fields[user]=email&include=author",
+      );
     });
 
     it("urlOmit is alias-aware on filters and sorts", () => {
@@ -309,11 +341,11 @@ describe("serializeSearchParams", () => {
         serializeSearchParams(
           {
             filters: [
-              { attribute: "dni",  value: ["123"] },
+              { attribute: "dni", value: ["123"] },
               { attribute: "name", value: ["x"] },
             ],
             sorts: [
-              { attribute: "dni",  direction: "asc" },
+              { attribute: "dni", direction: "asc" },
               { attribute: "name", direction: "asc" },
             ],
           },
@@ -321,7 +353,7 @@ describe("serializeSearchParams", () => {
             urlAliases: { dni: "documento" },
             urlOmit: {
               filters: ["documento"], // listed by WIRE name → state "dni" also dropped
-              sorts:   ["dni"],       // listed by STATE name → wire "dni" also dropped
+              sorts: ["dni"], // listed by STATE name → wire "dni" also dropped
             },
           },
         ),

--- a/tests/Units/utils.ts
+++ b/tests/Units/utils.ts
@@ -20,7 +20,7 @@ export const initialState: GlobalState = {
   pagination: {},
 } as const;
 
-export const initialConfig: BaseConfig<NonNullable<unknown>> = {
+export const initialConfig = {
   aliases: {},
   includes: [],
   sorts: [],
@@ -38,4 +38,4 @@ export const initialConfig: BaseConfig<NonNullable<unknown>> = {
   params: {},
   pagination: undefined,
   fields: [],
-};
+} satisfies BaseConfig<NonNullable<unknown>>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
-    "removeComments": true,
+    "removeComments": false,
     "skipLibCheck": true,
     "strict": true,
     "paths": {


### PR DESCRIPTION
## Summary

- Adds `QueryBuilderAdapter` (`read()` + optional `write(state)`) on `BaseConfig.adapter` — bridges the builder to any external source (URL, localStorage, hash router, in-memory, …) with **lazy one-shot read** on creation and an opt-in **per-mutation write** for two-way binding.
- Adds the built-in `createSearchParamsAdapter` for the URL case (configurable keys for `filter` / `sort` / `include` / `fields`, explicit `allowedParams` allowlist, injectable `source` for SSR/tests).
- Exports the pure `parseSearchParams` helper for ad-hoc use without the adapter wrapper.
- Fixes a latent bug in `useQueryBuilder` where `useRef(new Builder(config))` re-evaluated `new Builder()` on every render (only the first ref value was kept). The new lazy-ref pattern guarantees `adapter.read()` runs exactly once.
- Docs: new "Hydrating from URL" section in `README.md`, "Adapters" section in `llms.txt`, and two new live examples in `docs/playground.html` (**URL Adapter** and **localStorage Adapter**).
- **Playground**: adds an inline **localStorage inspector** that appears only when the *localStorage Adapter* tab is active — a textarea wired to the `rqb-playground-demo` key with **Sample** and **Save & Run** buttons, inline JSON validation, and auto-refresh after every Run (preserving focus so user edits aren't clobbered). Lets people drive the demo end-to-end without devtools.

### API at a glance

```ts
// URL hydration with custom keys + extra params allowed
useQueryBuilder({
  adapter: createSearchParamsAdapter({
    keys: { filter: "filt", sort: "srt" },
    allowedParams: ["locale"],
  }),
})

// Custom adapter (e.g. localStorage two-way binding)
useQueryBuilder({
  adapter: {
    read:  () => JSON.parse(localStorage.getItem("qb") ?? "{}"),
    write: (state) => localStorage.setItem("qb", JSON.stringify(state)),
  },
})
```

Precedence on seed: **defaults < `adapter.read()` < explicit `BaseConfig` fields** — explicit config always wins.

### Patterns used

- **Adapter / Strategy** for the read/write boundary — any source plugs in by implementing the interface.
- **Lazy Initialization** in the hook, matching `useState(() => …)` semantics.
- **Dependency Inversion** — the library no longer needs to import `window`; `window.location.search` lives inside the opt-in factory's default `source`.

## Test plan

- [x] `pnpm test` — 188/188 passing (3 new hook tests + dedicated suites for parser and adapter)
- [x] `pnpm lint` — clean
- [x] `pnpm build:types` — clean
- [ ] Manually open `docs/playground.html` and click **URL Adapter** → confirm the hydrated state appears in the right panel
- [x] Manually open `docs/playground.html`, click **localStorage Adapter**, then **Sample** → **Save & Run** → confirm the builder hydrates from the textarea JSON
- [ ] Run code that mutates the builder and confirm the textarea auto-refreshes (unless focused) to reflect what `write()` persisted
- [ ] Smoke test in a consumer app: navigate to `?filt[status]=active&srt=-name&locale=es` with the renamed keys and confirm `builder.build()` produces the canonical `?filter[status]=active&sort=-name&locale=es`